### PR TITLE
Allow `qgis_result_single()` function to be runned without `what` parameter

### DIFF
--- a/R/qgis-result.R
+++ b/R/qgis-result.R
@@ -66,14 +66,16 @@ qgis_check_stdout <- function(x) {
 #' @export
 qgis_result_single <- function(x, what) {
   # Limit result to elements that match class
-  x <- x[vapply(x, inherits, what, FUN.VALUE = logical(1))]
-  if (length(x) == 0L) {
-    abort(
-      paste(
-        "Can't extract object from result: zero outputs of type",
-        paste(what, collapse = " or ")
+  if (!missing(what)) {
+    x <- x[vapply(x, inherits, what, FUN.VALUE = logical(1))]
+    if (length(x) == 0L) {
+      abort(
+        paste(
+          "Can't extract object from result: zero outputs of type",
+          paste(what, collapse = " or ")
+        )
       )
-    )
+    }
   }
 
   # By default, take the first element named as output or OUTPUT.

--- a/tests/testthat/test-qgis-result.R
+++ b/tests/testthat/test-qgis-result.R
@@ -40,6 +40,10 @@ test_that("qgis_result_*() functions work", {
     qgis_result_single(result, "qgis_outputVector"),
     result$OUTPUT
   )
+  expect_identical(
+    qgis_result_single(result),
+    result$OUTPUT
+  )
 
   result$.processx_result$stdout <- ""
   expect_error(qgis_check_stdout(result), "output could not be captured")


### PR DESCRIPTION
This allows running `qgis_result_single()` without `what` parameter, extracting the output by name or position. 

The idea is to allow extraction of single result even in cases when we don't know what type of output we want. This is related to [#JanCaha/r_package_qgis/issues/31](https://github.com/JanCaha/r_package_qgis/issues/31).

All the tests should be working :) 