### PR TITLE
Use .quiet=TRUE by default in qgis_run_algorithm()

### DIFF
--- a/R/qgis-algorithms.R
+++ b/R/qgis-algorithms.R
@@ -6,6 +6,8 @@
 #' 'out of the box' on QGIS (versions >= 3.14).
 #'
 #' @param provider A provider identifier (e.g., "native")
+#' @param quiet Use `FALSE` to display more information about the command,
+#' possibly useful for debugging.
 #' @inheritParams qgis_run_algorithm
 #' @inheritParams qgis_run
 #'

--- a/R/qgis-configure.R
+++ b/R/qgis-configure.R
@@ -32,8 +32,8 @@
 #'
 #' @param ... Passed to [processx::run()].
 #' @param args Command-line arguments
-#' @param quiet Use `FALSE` to display more information about the command, possibly
-#'   useful for debugging.
+#' @param quiet Use `FALSE` to display more information about the command,
+#' possibly useful for debugging.
 #' @param query Use `TRUE` to refresh the cached value.
 #' @param action An action to take if the 'qgis_process' executable could not be
 #'   found.

--- a/R/qgis-run-algorithm.R
+++ b/R/qgis-run-algorithm.R
@@ -12,7 +12,8 @@
 #' @param ... Named key-value pairs as arguments for each algorithm. Features of
 #'   [rlang::list2()] are supported. These arguments
 #'   are converted to strings using [as_qgis_argument()].
-#' @param .quiet Use `TRUE` to suppress output from processing algorithms.
+#' @param .quiet Use `FALSE` to get extra output from processing algorithms.
+#' This can be useful in debugging.
 #' @param .raw_json_input The raw JSON to use as input in place of `...`.
 #'
 #' @export

--- a/R/qgis-run-algorithm.R
+++ b/R/qgis-run-algorithm.R
@@ -82,7 +82,7 @@ qgis_run_algorithm <- function(algorithm, ..., PROJECT_PATH = NULL, ELLIPSOID = 
     ),
     echo_cmd = !.quiet,
     stdout_callback = if (!.quiet && !use_json_output) function(x, ...) cat(x),
-    stderr_callback = if (!.quiet) function(x, ...) message(x, appendLF = FALSE),
+    stderr_callback = function(x, ...) message(x, appendLF = FALSE),
     stdin = if (use_json_input) stdin_file,
     encoding = if (use_json_output) "UTF-8" else ""
   )

--- a/R/qgis-run-algorithm.R
+++ b/R/qgis-run-algorithm.R
@@ -1,9 +1,9 @@
 #' Run algorithms using 'qgis_process'
 #'
 #' Run QGIS algorithms.
-#' See the [QGIS docs](https://docs.qgis.org/testing/en/docs/user_manual/processing_algs/qgis/index.html)
+#' See the [QGIS docs](https://docs.qgis.org/latest/en/docs/user_manual/processing_algs/qgis/index.html)
 #' for a detailed description of the algorithms provided
-#' 'out of the box' on QGIS (versions >= 3.14).
+#' 'out of the box' on QGIS.
 #'
 #' @param algorithm A qualified algorithm name (e.g., "native:filedownloader") or
 #'   a path to a QGIS model file.

--- a/R/qgis-run-algorithm.R
+++ b/R/qgis-run-algorithm.R
@@ -27,7 +27,7 @@
 #' }
 #'
 qgis_run_algorithm <- function(algorithm, ..., PROJECT_PATH = NULL, ELLIPSOID = NULL,
-                               .raw_json_input = NULL, .quiet = FALSE) {
+                               .raw_json_input = NULL, .quiet = TRUE) {
   assert_qgis()
   assert_qgis_algorithm(algorithm)
 

--- a/man/qgis_function.Rd
+++ b/man/qgis_function.Rd
@@ -37,7 +37,8 @@ Defaults to \code{"OUTPUT"}.}
 Should an incoming \code{qgis_result} be cleaned (using \code{\link[=qgis_result_clean]{qgis_result_clean()}})
 after processing?}
 
-\item{.quiet}{Use \code{TRUE} to suppress output from processing algorithms.}
+\item{.quiet}{Use \code{FALSE} to get extra output from processing algorithms.
+This can be useful in debugging.}
 }
 \description{
 As opposed to \code{\link[=qgis_run_algorithm]{qgis_run_algorithm()}}, \code{\link[=qgis_function]{qgis_function()}} creates a callable

--- a/man/qgis_has_algorithm.Rd
+++ b/man/qgis_has_algorithm.Rd
@@ -24,7 +24,8 @@ a path to a QGIS model file.}
 
 \item{query}{Use \code{TRUE} to refresh the cached value.}
 
-\item{quiet}{Use \code{TRUE} to suppress output from processing algorithms.}
+\item{quiet}{Use \code{FALSE} to display more information about the command,
+possibly useful for debugging.}
 
 \item{provider}{A provider identifier (e.g., "native")}
 }

--- a/man/qgis_plugins.Rd
+++ b/man/qgis_plugins.Rd
@@ -19,8 +19,8 @@ Must be one of: \code{"all"}, \code{"enabled"}, \code{"disabled"}.}
 
 \item{query}{Use \code{TRUE} to refresh the cached value.}
 
-\item{quiet}{Use \code{FALSE} to display more information about the command, possibly
-useful for debugging.}
+\item{quiet}{Use \code{FALSE} to display more information about the command,
+possibly useful for debugging.}
 
 \item{...}{Only used by other functions calling this function.}
 

--- a/man/qgis_run.Rd
+++ b/man/qgis_run.Rd
@@ -45,8 +45,8 @@ qgis_env()
 \item{action}{An action to take if the 'qgis_process' executable could not be
 found.}
 
-\item{quiet}{Use \code{FALSE} to display more information about the command, possibly
-useful for debugging.}
+\item{quiet}{Use \code{FALSE} to display more information about the command,
+possibly useful for debugging.}
 
 \item{use_cached_data}{Use the cached algorithm list and \code{path} found when
 configuring qgisprocess during the last session. This saves some time

--- a/man/qgis_run_algorithm.Rd
+++ b/man/qgis_run_algorithm.Rd
@@ -10,7 +10,7 @@ qgis_run_algorithm(
   PROJECT_PATH = NULL,
   ELLIPSOID = NULL,
   .raw_json_input = NULL,
-  .quiet = FALSE
+  .quiet = TRUE
 )
 }
 \arguments{

--- a/man/qgis_run_algorithm.Rd
+++ b/man/qgis_run_algorithm.Rd
@@ -31,9 +31,9 @@ This can be useful in debugging.}
 }
 \description{
 Run QGIS algorithms.
-See the \href{https://docs.qgis.org/testing/en/docs/user_manual/processing_algs/qgis/index.html}{QGIS docs}
+See the \href{https://docs.qgis.org/latest/en/docs/user_manual/processing_algs/qgis/index.html}{QGIS docs}
 for a detailed description of the algorithms provided
-'out of the box' on QGIS (versions >= 3.14).
+'out of the box' on QGIS.
 }
 \examples{
 if (has_qgis()) {

--- a/man/qgis_run_algorithm.Rd
+++ b/man/qgis_run_algorithm.Rd
@@ -26,7 +26,8 @@ ellipsoid name for distance calculations.}
 
 \item{.raw_json_input}{The raw JSON to use as input in place of \code{...}.}
 
-\item{.quiet}{Use \code{TRUE} to suppress output from processing algorithms.}
+\item{.quiet}{Use \code{FALSE} to get extra output from processing algorithms.
+This can be useful in debugging.}
 }
 \description{
 Run QGIS algorithms.


### PR DESCRIPTION
Fixes #145. But ignores https://github.com/r-spatial/qgisprocess/pull/134#issuecomment-1490834960 :wink:... To be thought through further.

Plus a few documentation tweaks.

Also some roxygen-side effect (bug?) has been worked around, where an explanation of `@param .quiet` was automatically taken as explanation of the `quiet` (no dot) argument in some other functions as a consequence of `@inheritParams` (what??).