### PR TITLE
Update GHA workflows

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -68,7 +68,7 @@ jobs:
           sudo gpg --no-default-keyring --keyring /etc/apt/keyrings/ubuntugis-unstable-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 6B827C12C2D425E227EDCA75089EBE08314DF160
           sudo sh -c 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/ubuntugis-unstable-archive-keyring.gpg] http://ppa.launchpad.net/ubuntugis/ubuntugis-unstable/ubuntu `lsb_release -c -s` main" > /etc/apt/sources.list.d/ubuntugis-unstable.list'
           sudo wget -qO /etc/apt/keyrings/qgis-archive-keyring.gpg https://download.qgis.org/downloads/qgis-archive-keyring.gpg
-          sudo sh -c 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/qgis-archive-keyring.gpg] https://qgis.org/ubuntugis `lsb_release -c -s` main" > /etc/apt/sources.list.d/qgis.list'
+          sudo sh -c 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/qgis-archive-keyring.gpg] https://qgis.org/ubuntugis-nightly-release `lsb_release -c -s` main" > /etc/apt/sources.list.d/qgis.list'
           sudo apt-get update
           sudo apt-get install -y qgis qgis-plugin-grass saga
           wget -qO sagang_plugin.zip https://plugins.qgis.org/plugins/processing_saga_nextgen/version/$SAGANGV/download/

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -48,7 +48,7 @@ jobs:
           mkdir extra_plugins
           echo "QGIS_PLUGINPATH=$(pwd)/extra_plugins" >> $GITHUB_ENV
 
-      - name: Install QGIS (Ubuntu Nightly QGIS repo + possibly older GRASS from Ubuntu repo)
+      - name: Install QGIS development version for Ubuntu (using an often outdated GRASS release from Ubuntu repo)
         if: matrix.config.qgis == 'ubuntu-nightly'
         run: |
           # Setup QGIS from Ubuntu Nightly
@@ -59,7 +59,7 @@ jobs:
           wget -qO sagang_plugin.zip https://plugins.qgis.org/plugins/processing_saga_nextgen/version/$SAGANGV/download/
           unzip -q sagang_plugin.zip -d extra_plugins
 
-      - name: Install QGIS (Ubuntugis QGIS repo + ubuntugis-unstable PPA, which has the current GRASS release)
+      - name: Install upcoming QGIS point release (= latest release in < 1 month) for Ubuntugis (ubuntugis-unstable PPA, with current GRASS release)
         if: matrix.config.qgis == 'ubuntugis'
         run: |
           # Setup QGIS from Ubuntugis
@@ -74,7 +74,7 @@ jobs:
           wget -qO sagang_plugin.zip https://plugins.qgis.org/plugins/processing_saga_nextgen/version/$SAGANGV/download/
           unzip -q sagang_plugin.zip -d extra_plugins
 
-      - name: Install QGIS (Ubuntu QGIS repo + possibly older GRASS from Ubuntu repo)
+      - name: Install latest QGIS release for Ubuntu (using an often outdated GRASS release from Ubuntu repo)
         if: matrix.config.qgis == 'ubuntu'
         run: |
           # Setup QGIS from Ubuntu

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -25,6 +25,7 @@ jobs:
           - {os: ubuntu-22.04, qgis: 'ubuntu-nightly', r: 'release', r-pkg-cache: 'v0'}
           - {os: ubuntu-22.04, qgis: 'ubuntugis', r: 'release', r-pkg-cache: 'v1'}
           - {os: ubuntu-22.04, qgis: 'ubuntu', r: 'release', r-pkg-cache: 'v0'}
+          - {os: ubuntu-22.04, qgis: 'ubuntu-ltr', r: 'release', r-pkg-cache: 'v0'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -80,6 +81,17 @@ jobs:
           # Setup QGIS from Ubuntu
           sudo wget -qO /etc/apt/keyrings/qgis-archive-keyring.gpg https://download.qgis.org/downloads/qgis-archive-keyring.gpg
           sudo sh -c 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/qgis-archive-keyring.gpg] https://qgis.org/ubuntu `lsb_release -c -s` main" > /etc/apt/sources.list.d/qgis.list'
+          sudo apt-get update
+          sudo apt-get install -y qgis qgis-plugin-grass saga
+          wget -qO sagang_plugin.zip https://plugins.qgis.org/plugins/processing_saga_nextgen/version/$SAGANGV/download/
+          unzip -q sagang_plugin.zip -d extra_plugins
+
+      - name: Install QGIS LTR (long-term release) for Ubuntu (using an often outdated GRASS release from Ubuntu repo)
+        if: matrix.config.qgis == 'ubuntu-ltr'
+        run: |
+          # Setup QGIS from Ubuntu
+          sudo wget -qO /etc/apt/keyrings/qgis-archive-keyring.gpg https://download.qgis.org/downloads/qgis-archive-keyring.gpg
+          sudo sh -c 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/qgis-archive-keyring.gpg] https://qgis.org/ubuntu-ltr `lsb_release -c -s` main" > /etc/apt/sources.list.d/qgis.list'
           sudo apt-get update
           sudo apt-get install -y qgis qgis-plugin-grass saga
           wget -qO sagang_plugin.zip https://plugins.qgis.org/plugins/processing_saga_nextgen/version/$SAGANGV/download/

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -46,8 +46,8 @@ jobs:
       - name: In Linux, dynamically set QGIS_PLUGINPATH environment var (available to next steps)
         if: runner.os == 'Linux'
         run: |
-          mkdir extra_plugins
-          echo "QGIS_PLUGINPATH=$(pwd)/extra_plugins" >> $GITHUB_ENV
+          mkdir ../extra_plugins
+          echo "QGIS_PLUGINPATH=$(pwd)/../extra_plugins" >> $GITHUB_ENV
 
       - name: Install QGIS development version for Ubuntu (using an often outdated GRASS release from Ubuntu repo)
         if: matrix.config.qgis == 'ubuntu-nightly'
@@ -57,8 +57,8 @@ jobs:
           sudo sh -c 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/qgis-archive-keyring.gpg] https://qgis.org/ubuntu-nightly `lsb_release -c -s` main" > /etc/apt/sources.list.d/qgis.list'
           sudo apt-get update
           sudo apt-get install -y qgis qgis-plugin-grass saga
-          wget -qO sagang_plugin.zip https://plugins.qgis.org/plugins/processing_saga_nextgen/version/$SAGANGV/download/
-          unzip -q sagang_plugin.zip -d extra_plugins
+          wget -qO ../sagang_plugin.zip https://plugins.qgis.org/plugins/processing_saga_nextgen/version/$SAGANGV/download/
+          unzip -q ../sagang_plugin.zip -d ../extra_plugins
 
       - name: Install upcoming QGIS point release (= latest release in < 1 month) for Ubuntugis (ubuntugis-unstable PPA, with current GRASS release)
         if: matrix.config.qgis == 'ubuntugis'
@@ -72,8 +72,8 @@ jobs:
           sudo sh -c 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/qgis-archive-keyring.gpg] https://qgis.org/ubuntugis-nightly-release `lsb_release -c -s` main" > /etc/apt/sources.list.d/qgis.list'
           sudo apt-get update
           sudo apt-get install -y qgis qgis-plugin-grass saga
-          wget -qO sagang_plugin.zip https://plugins.qgis.org/plugins/processing_saga_nextgen/version/$SAGANGV/download/
-          unzip -q sagang_plugin.zip -d extra_plugins
+          wget -qO ../sagang_plugin.zip https://plugins.qgis.org/plugins/processing_saga_nextgen/version/$SAGANGV/download/
+          unzip -q ../sagang_plugin.zip -d ../extra_plugins
 
       - name: Install latest QGIS release for Ubuntu (using an often outdated GRASS release from Ubuntu repo)
         if: matrix.config.qgis == 'ubuntu'
@@ -83,8 +83,8 @@ jobs:
           sudo sh -c 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/qgis-archive-keyring.gpg] https://qgis.org/ubuntu `lsb_release -c -s` main" > /etc/apt/sources.list.d/qgis.list'
           sudo apt-get update
           sudo apt-get install -y qgis qgis-plugin-grass saga
-          wget -qO sagang_plugin.zip https://plugins.qgis.org/plugins/processing_saga_nextgen/version/$SAGANGV/download/
-          unzip -q sagang_plugin.zip -d extra_plugins
+          wget -qO ../sagang_plugin.zip https://plugins.qgis.org/plugins/processing_saga_nextgen/version/$SAGANGV/download/
+          unzip -q ../sagang_plugin.zip -d ../extra_plugins
 
       - name: Install QGIS LTR (long-term release) for Ubuntu (using an often outdated GRASS release from Ubuntu repo)
         if: matrix.config.qgis == 'ubuntu-ltr'
@@ -94,8 +94,8 @@ jobs:
           sudo sh -c 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/qgis-archive-keyring.gpg] https://qgis.org/ubuntu-ltr `lsb_release -c -s` main" > /etc/apt/sources.list.d/qgis.list'
           sudo apt-get update
           sudo apt-get install -y qgis qgis-plugin-grass saga
-          wget -qO sagang_plugin.zip https://plugins.qgis.org/plugins/processing_saga_nextgen/version/$SAGANGV/download/
-          unzip -q sagang_plugin.zip -d extra_plugins
+          wget -qO ../sagang_plugin.zip https://plugins.qgis.org/plugins/processing_saga_nextgen/version/$SAGANGV/download/
+          unzip -q ../sagang_plugin.zip -d ../extra_plugins
 
       - name: Install QGIS (MacOS homebrew)
         if: matrix.config.qgis == 'macos-brew'

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -26,8 +26,8 @@ jobs:
 
       - name: Dynamically set QGIS_PLUGINPATH environment var (available to next steps)
         run: |
-          mkdir extra_plugins
-          echo "QGIS_PLUGINPATH=$(pwd)/extra_plugins" >> $GITHUB_ENV
+          mkdir ../extra_plugins
+          echo "QGIS_PLUGINPATH=$(pwd)/../extra_plugins" >> $GITHUB_ENV
 
       - name: Install QGIS (Ubuntu)
         run: |
@@ -35,8 +35,8 @@ jobs:
           sudo sh -c 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/qgis-archive-keyring.gpg] https://qgis.org/ubuntu `lsb_release -c -s` main" > /etc/apt/sources.list.d/qgis.list'
           sudo apt-get update
           sudo apt-get install -y qgis qgis-plugin-grass saga
-          wget -qO sagang_plugin.zip https://plugins.qgis.org/plugins/processing_saga_nextgen/version/$SAGANGV/download/
-          unzip -q sagang_plugin.zip -d extra_plugins
+          wget -qO ../sagang_plugin.zip https://plugins.qgis.org/plugins/processing_saga_nextgen/version/$SAGANGV/download/
+          unzip -q ../sagang_plugin.zip -d ../extra_plugins
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/R/qgis-state.R
+++ b/R/qgis-state.R
@@ -7,6 +7,10 @@
 #' @concept functions to manage and explore QGIS and qgisprocess
 #' @seealso [qgis_configure()]
 #'
+#' @param full Logical.
+#' If `FALSE`, only return the `"x.y.z"` version string instead of the full
+#' version string that includes the name.
+#' Defaults to `TRUE`; ignored if `debug = TRUE`.
 #' @param debug Logical.
 #' If `TRUE`, also output the version of QGIS, the operating system and all
 #' relevant libraries, as reported by the 'qgis_process' command.
@@ -133,7 +137,7 @@ qgis_query_path <- function(quiet = FALSE) {
 
 #' @rdname qgis_path
 #' @export
-qgis_version <- function(query = FALSE, quiet = TRUE, debug = FALSE) {
+qgis_version <- function(query = FALSE, quiet = TRUE, full = TRUE, debug = FALSE) {
   if (query) qgisprocess_cache$version <- qgis_query_version(quiet = quiet)
 
   if (!quiet) {
@@ -144,8 +148,10 @@ qgis_version <- function(query = FALSE, quiet = TRUE, debug = FALSE) {
     )
   }
 
+  if (!full || debug) short <- strsplit(qgisprocess_cache$version, "-")[[1]][1]
+
   if (debug) {
-    if (package_version(strsplit(qgis_version(), "-")[[1]][1]) < "3.22.0") {
+    if (package_version(short) < "3.22.0") {
       warning("'debug = TRUE' is not supported for QGIS versions < 3.22")
       return(qgisprocess_cache$version)
     }
@@ -157,7 +163,7 @@ qgis_version <- function(query = FALSE, quiet = TRUE, debug = FALSE) {
     return(invisible(qgisprocess_cache$version))
   }
 
-  qgisprocess_cache$version
+  if (full) qgisprocess_cache$version else short
 }
 
 

--- a/R/qgis-state.R
+++ b/R/qgis-state.R
@@ -271,7 +271,7 @@ qgis_using_json_input <- function() {
 
   if (identical(opt, "")) {
     qgis_using_json_output() &&
-      (package_version(strsplit(qgis_version(), "-")[[1]][1]) >= "3.23.0")
+      (package_version(qgis_version(full = FALSE)) >= "3.23.0")
   } else {
     isTRUE(opt) || identical(opt, "true")
   }

--- a/man/qgis_path.Rd
+++ b/man/qgis_path.Rd
@@ -7,13 +7,18 @@
 \usage{
 qgis_path(query = FALSE, quiet = TRUE)
 
-qgis_version(query = FALSE, quiet = TRUE, debug = FALSE)
+qgis_version(query = FALSE, quiet = TRUE, full = TRUE, debug = FALSE)
 }
 \arguments{
 \item{query}{Use \code{TRUE} to refresh the cached value.}
 
 \item{quiet}{Use \code{FALSE} to display more information,
 possibly useful for debugging.}
+
+\item{full}{Logical.
+If \code{FALSE}, only return the \code{"x.y.z"} version string instead of the full
+version string that includes the name.
+Defaults to \code{TRUE}; ignored if \code{debug = TRUE}.}
 
 \item{debug}{Logical.
 If \code{TRUE}, also output the version of QGIS, the operating system and all

--- a/man/vignette_childs/_qgis_expressions.Rmd
+++ b/man/vignette_childs/_qgis_expressions.Rmd
@@ -88,7 +88,7 @@ The `load_layer()` approach since QGIS 3.30.0 avoids the need for a QGIS project
 
 Now we can run the algorithm:
 
-```{r eval=(package_version(strsplit(qgis_version(), "-")[[1]][1]) >= "3.30.0") && !qgisprocess:::is_windows()}
+```{r eval=!qgisprocess:::is_windows()}
 qgis_run_algorithm(
   "native:fieldcalculator",
   INPUT = longlake_depth_path,

--- a/tests/testthat/test-qgis-configure.R
+++ b/tests/testthat/test-qgis-configure.R
@@ -2,6 +2,7 @@ test_that("qgis_version() works", {
   skip_if_not(has_qgis())
 
   expect_match(qgis_version(), "^\\d{1,2}\\.\\d+.*-.+")
+  expect_match(qgis_version(full = FALSE), "^\\d{1,2}\\.\\d+.\\d+$")
 })
 
 test_that("qgis_version(debug = TRUE) works", {

--- a/tests/testthat/test-qgis-configure.R
+++ b/tests/testthat/test-qgis-configure.R
@@ -8,7 +8,7 @@ test_that("qgis_version() works", {
 test_that("qgis_version(debug = TRUE) works", {
   skip_if_not(has_qgis())
   skip_if(
-    package_version(strsplit(qgis_version(), "-")[[1]][1]) < "3.22.0",
+    package_version(qgis_version(full = FALSE)) < "3.22.0",
     "QGIS version is older than 3.22.0"
   )
 

--- a/tests/testthat/test-qgis-run-algorithm2.R
+++ b/tests/testthat/test-qgis-run-algorithm2.R
@@ -1,6 +1,6 @@
 # Flip qgis_using_json_input() and rerun test-qgis-run-algorithm.R
 
-if (has_qgis() && package_version(strsplit(qgis_version(), "-")[[1]][1]) >= "3.23.0") {
+if (has_qgis() && package_version(qgis_version(full = FALSE)) >= "3.23.0") {
   withr::local_envvar(c(JSON_INPUT = qgis_using_json_input()))
   withr::local_options(qgisprocess.use_json_input = !qgis_using_json_input())
 

--- a/vignettes/qgis_expressions.Rmd
+++ b/vignettes/qgis_expressions.Rmd
@@ -14,6 +14,8 @@ knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
 )
+can_build <- qgisprocess::has_qgis() &&
+  package_version(qgisprocess::qgis_version(full = FALSE)) >= "3.30.0"
 ```
 
 ```{r setup, message=FALSE}
@@ -21,11 +23,11 @@ library(qgisprocess)
 library(sf)
 ```
 
-```{r child=if (has_qgis()) file.path(rprojroot::find_root(rprojroot::is_r_package), "man/vignette_childs/_qgis_expressions.Rmd")}
+```{r child=if (can_build) file.path(rprojroot::find_root(rprojroot::is_r_package), "man/vignette_childs/_qgis_expressions.Rmd")}
 ```
 
-```{r eval=!has_qgis(), echo=FALSE, results="asis"}
-cat("This vignette has been built in absence of a QGIS installation.\n\n")
+```{r eval=!can_build, echo=FALSE, results="asis"}
+cat("This vignette has been built in absence of a QGIS installation with version >= 3.30.0.\n\n")
 cat("Read it online at <https://r-spatial.github.io/qgisprocess/articles/qgis_expressions.html>.")
 ```
 


### PR DESCRIPTION
- handle extra plugins outside of the package source code (but at a level next to it) - in order not to bother R CMD check.
- update the R-CMD-check _ubuntugis_ job to using QGIS from the `ubuntugis-nightly-release` repo, in order to minimize QGIS installation problems when a new GRASS GIS release is out.
- add a R-CMD-check job that uses QGIS LTR, in Ubuntu. QGIS LTR had not been included in the workflow so far, but is officially supported.

Meanwhile, checking for minimal QGIS versions throughout the package has been made easier by adding a `full` argument (default `TRUE`) to `qgis_version()`. `qgis_version(full = FALSE)` just returns version number x.y.z, i.e. without the QGIS version name, so for example `"3.30.2"`.