### PR TITLE
qgis_cache_dir(): avoid warning when dir non-existing

### DIFF
--- a/R/qgis-cache.R
+++ b/R/qgis-cache.R
@@ -1,6 +1,6 @@
 #' @keywords internal
 qgis_cache_dir <- function() {
-  normalizePath(rappdirs::user_cache_dir("R-qgisprocess"))
+  normalizePath(rappdirs::user_cache_dir("R-qgisprocess"), mustWork = FALSE)
 }
 
 #' @keywords internal


### PR DESCRIPTION
Attempting to resolve note:

```
* checking whether the namespace can be loaded with stated dependencies ... NOTE
Warning in normalizePath(rappdirs::user_cache_dir("R-qgisprocess")) :
  path[1]="/Users/runner/Library/Caches/R-qgisprocess": No such file or directory
A namespace must be able to be loaded with just the base namespace
loaded: otherwise if the namespace gets loaded by a saved object, the
session will be unable to start.
Probably some imports need to be declared in the NAMESPACE file.
```

Being tricked by the caching of GH Actions here, since it seems to include the cache dir in case of QGIS present. The NOTE popped up in the winbuilder & R-hub systems, but in GHA only on some occasions (i.e. with invalid runner cache, e.g. above for macOS).