### PR TITLE
Protect against a 'soft' package configuration failure.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qgisprocess
 Title: Use 'QGIS' Processing Algorithms
-Version: 0.1.0.9000
+Version: 0.1.0.9177
 Authors@R: c(
     person("Dewey", "Dunnington", , "dewey@fishandwhistle.net", role = "aut",
            comment = c(ORCID = "0000-0002-9415-4582", affiliation = "Voltron Data")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # qgisprocess (development version)
 
+- Solve a CRAN check error on `r-oldrel-macos-x86_64`, by adding support for {stars} 0.5-5 (#175).
+- Allow half-configured states with abundant messages, so that remaining functionality can be used in debugging or even for some real stuff (#177).
+
 # qgisprocess 0.1.0
 
 - Initial CRAN release.

--- a/R/qgis-algorithms.R
+++ b/R/qgis-algorithms.R
@@ -44,7 +44,6 @@ qgis_algorithms <- function(query = FALSE, quiet = TRUE) {
 #' @rdname qgis_algorithms
 #' @export
 qgis_providers <- function(query = FALSE, quiet = TRUE) {
-  assert_qgis()
   algs <- qgis_algorithms(query = query, quiet = quiet)
   counted <- stats::aggregate(
     algs[[1]],

--- a/R/qgis-algorithms.R
+++ b/R/qgis-algorithms.R
@@ -79,6 +79,14 @@ assert_qgis_algorithm <- function(algorithm) {
 qgis_query_algorithms <- function(quiet = FALSE) {
   if (qgis_using_json_output()) {
     result <- qgis_run(args = c("list", "--json"), encoding = "UTF-8")
+    if (nchar(result$stderr) > 0L) {
+      message(
+        "\nStandard error message emitted by the 'qgis_process' command ",
+        "(non-fatal at this stage):\n",
+        result$stderr,
+        "\n"
+      )
+    }
     result_parsed <- jsonlite::fromJSON(result$stdout)
 
     providers_ptype <- tibble::tibble(

--- a/R/qgis-cache.R
+++ b/R/qgis-cache.R
@@ -88,8 +88,7 @@ qgis_delete_old_cachefiles <- function(
     error = function(e) {
       message(glue(
         "Cache files older than {age_days} days could not be deleted. ",
-        "Error message was: ",
-        e$stderr
+        "Error message was:\n{e}"
       ))
     }
   )

--- a/R/qgis-configure.R
+++ b/R/qgis-configure.R
@@ -297,12 +297,11 @@ qgis_reconfigure <- function(cache_data_file, quiet = FALSE) {
     },
     error = function(e) {
       message(glue(
-        "\nATTENTION: the QGIS version could not be queried. ",
+        "\n\nATTENTION: the QGIS version could not be queried. ",
         "You will loose some functionality.\n",
-        "You may want to (re)run `qgis_configure()`; see its documentation.\n",
-        "Error message was:\n",
-        e$stderr,
-        "\n"
+        "You may want to run `qgis_version(query = TRUE)` followed by ",
+        "`qgis_configure()`; see its documentation.\n",
+        "Error message was:\n{e}\n"
       ))
     }
   )
@@ -320,12 +319,10 @@ qgis_reconfigure <- function(cache_data_file, quiet = FALSE) {
     },
     error = function(e) {
       message(glue(
-        "\nATTENTION: the QGIS plugins could not be queried. ",
+        "\n\nATTENTION: the QGIS plugins could not be queried. ",
         "You will loose some functionality.\n",
         "You may want to (re)run `qgis_configure()`; see its documentation.\n",
-        "Error message was:\n",
-        e$stderr,
-        "\n"
+        "Error message was:\n{e}\n"
       ))
     }
   )
@@ -336,12 +333,10 @@ qgis_reconfigure <- function(cache_data_file, quiet = FALSE) {
     },
     error = function(e) {
       message(glue(
-        "\nATTENTION: the QGIS algorithms could not be queried. ",
+        "\n\nATTENTION: the QGIS algorithms could not be queried. ",
         "You will loose some functionality.\n",
         "You may want to (re)run `qgis_configure()`; see its documentation.\n",
-        "Error message was:\n",
-        e$stderr,
-        "\n"
+        "Error message was:\n{e}\n"
       ))
     }
   )

--- a/R/qgis-configure.R
+++ b/R/qgis-configure.R
@@ -291,7 +291,21 @@ qgis_reconfigure <- function(cache_data_file, quiet = FALSE) {
   path <- qgis_path(query = TRUE, quiet = quiet)
   if (!quiet) message()
 
-  version <- qgis_version(query = TRUE, quiet = quiet)
+  tryCatch(
+    {
+      version <- qgis_version(query = TRUE, quiet = quiet)
+    },
+    error = function(e) {
+      message(glue(
+        "\nATTENTION: the QGIS version could not be queried. ",
+        "You will loose some functionality.\n",
+        "You may want to (re)run `qgis_configure()`; see its documentation.\n",
+        "Error message was:\n",
+        e$stderr,
+        "\n"
+      ))
+    }
+  )
 
   use_json_output <- qgis_using_json_output(query = TRUE, quiet = quiet)
 
@@ -300,32 +314,64 @@ qgis_reconfigure <- function(cache_data_file, quiet = FALSE) {
     "JSON for input serialization."
   )
 
-  plugins <- qgis_plugins(query = TRUE, quiet = quiet, msg = FALSE)
-
-  algorithms <- qgis_algorithms(query = TRUE, quiet = quiet)
-
-  if (!quiet) message_disabled_plugins(plugins, prepend_newline = TRUE)
-
-  if (!quiet) message(glue("\n\nSaving configuration to '{cache_data_file}'"))
-
-  try({
-    if (!dir.exists(dirname(cache_data_file))) {
-      dir.create(dirname(cache_data_file), recursive = TRUE)
+  tryCatch(
+    {
+      plugins <- qgis_plugins(query = TRUE, quiet = quiet, msg = FALSE)
+    },
+    error = function(e) {
+      message(glue(
+        "\nATTENTION: the QGIS plugins could not be queried. ",
+        "You will loose some functionality.\n",
+        "You may want to (re)run `qgis_configure()`; see its documentation.\n",
+        "Error message was:\n",
+        e$stderr,
+        "\n"
+      ))
     }
+  )
 
-    saveRDS(
-      list(
-        path = path,
-        version = version,
-        algorithms = algorithms,
-        plugins = plugins,
-        use_json_output = use_json_output
-      ),
-      cache_data_file
-    )
-  })
+  tryCatch(
+    {
+      algorithms <- qgis_algorithms(query = TRUE, quiet = quiet)
+    },
+    error = function(e) {
+      message(glue(
+        "\nATTENTION: the QGIS algorithms could not be queried. ",
+        "You will loose some functionality.\n",
+        "You may want to (re)run `qgis_configure()`; see its documentation.\n",
+        "Error message was:\n",
+        e$stderr,
+        "\n"
+      ))
+    }
+  )
 
-  if (!quiet) message_inspect_cache()
+  if (!quiet && exists("plugins")) message_disabled_plugins(plugins, prepend_newline = TRUE)
+
+  if (has_qgis()) {
+    if (!quiet) message(glue("\n\nSaving configuration to '{cache_data_file}'"))
+
+    try({
+      if (!dir.exists(dirname(cache_data_file))) {
+        dir.create(dirname(cache_data_file), recursive = TRUE)
+      }
+
+      saveRDS(
+        list(
+          path = path,
+          version = version,
+          algorithms = algorithms,
+          plugins = plugins,
+          use_json_output = use_json_output
+        ),
+        cache_data_file
+      )
+    })
+
+    if (!quiet) message_inspect_cache()
+  } else {
+    message(config_problem_msg)
+  }
 }
 
 

--- a/R/qgis-configure.R
+++ b/R/qgis-configure.R
@@ -369,7 +369,7 @@ qgis_reconfigure <- function(cache_data_file, quiet = FALSE) {
     })
 
     if (!quiet) message_inspect_cache()
-  } else {
+  } else if (!quiet) {
     message(config_problem_msg)
   }
 }

--- a/R/qgis-has.R
+++ b/R/qgis-has.R
@@ -49,10 +49,10 @@ assert_qgis <- function(action = abort) {
   if (!has_qgis()) {
     action(
       paste0(
-        "The QGIS processing utility ('qgis_process') is not installed or could not be found.\n",
-        "Run `qgis_configure()` to configure this location.\n",
-        "If 'qgis_process' is installed, set `options(qgisprocess.path = '/path/to/qgis_process')`\n",
-        "and re-run `qgis_configure()`."
+        "The 'qgis_process' command-line utility was either not found or\n",
+        "did not fulfil the needs to build the package cache.\n",
+        "Please run `qgis_configure()` to fix this and rebuild the cache.\n",
+        "See its documentation if you need to preset the path of qgis_process."
       )
     )
   }

--- a/R/qgis-plugins.R
+++ b/R/qgis-plugins.R
@@ -209,8 +209,7 @@ enable_plugin <- function(name, quiet = FALSE) {
     },
     error = function(e) {
       message(glue(
-        "'{name}' was not successfully enabled. Error message was: ",
-        e$stderr
+        "'{name}' was not successfully enabled. Error message was:\n{e}"
       ))
     }
   )
@@ -227,8 +226,7 @@ disable_plugin <- function(name, quiet = FALSE) {
     },
     error = function(e) {
       message(glue(
-        "'{name}' was not successfully disabled. Error message was: ",
-        e$stderr
+        "'{name}' was not successfully disabled. Error message was:\n{e}"
       ))
     }
   )

--- a/R/qgis-run.R
+++ b/R/qgis-run.R
@@ -32,6 +32,10 @@ qgis_run <- function(args = character(), ..., env = qgis_env(), path = qgis_path
       "For now, will try to fix it on the fly, but some functionality may not work.\n"
     )
     path <- qgis_path(query = TRUE, quiet = FALSE)
+    # typically the version will also be missing, so fixing that as well:
+    if (is.null(qgisprocess_cache$version)) {
+      invisible(qgis_version(query = TRUE, quiet = FALSE))
+    }
   }
   # workaround for running Windows batch files where arguments have spaces
   # see https://github.com/r-lib/processx/issues/301

--- a/R/qgis-run.R
+++ b/R/qgis-run.R
@@ -26,10 +26,10 @@
 qgis_run <- function(args = character(), ..., env = qgis_env(), path = qgis_path()) {
   if (is.null(path)) {
     message(
-      "'qgis_process' path is not present in the package cache.\n",
-      "The package is not well configured; some functionality may not work.\n",
+      "The filepath of 'qgis_process' is not present in the package cache, ",
+      "so the package is not well configured.\n",
       "Restart R and reload the package; run `qgis_configure()` if needed.\n",
-      "For now, will try to fix it on the fly.\n"
+      "For now, will try to fix it on the fly, but some functionality may not work.\n"
     )
     path <- qgis_path(query = TRUE, quiet = FALSE)
   }

--- a/R/qgis-run.R
+++ b/R/qgis-run.R
@@ -24,6 +24,15 @@
 #'
 #' @export
 qgis_run <- function(args = character(), ..., env = qgis_env(), path = qgis_path()) {
+  if (is.null(path)) {
+    message(
+      "'qgis_process' path is not present in the package cache.\n",
+      "The package is not well configured; some functionality may not work.\n",
+      "Restart R and reload the package; run `qgis_configure()` if needed.\n",
+      "For now, will try to fix it on the fly.\n"
+    )
+    path <- qgis_path(query = TRUE, quiet = FALSE)
+  }
   # workaround for running Windows batch files where arguments have spaces
   # see https://github.com/r-lib/processx/issues/301
   if (is_windows()) {

--- a/R/qgis-run.R
+++ b/R/qgis-run.R
@@ -43,7 +43,7 @@ qgis_run <- function(args = character(), ..., env = qgis_env(), path = qgis_path
   } else {
     withr::with_envvar(
       env,
-      processx::run(path, args, ...),
+      processx::run(path, args, ...)
     )
   }
 }

--- a/R/qgis-state.R
+++ b/R/qgis-state.R
@@ -283,6 +283,7 @@ qgis_using_json_input <- function() {
 
   if (identical(opt, "")) {
     qgis_using_json_output() &&
+      !is.null(qgis_version()) &&
       (package_version(qgis_version(full = FALSE)) >= "3.23.0")
   } else {
     isTRUE(opt) || identical(opt, "true")

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -29,17 +29,19 @@
     )
     message_disabled_plugins(qgisprocess_cache$plugins, startup = TRUE)
   } else {
-    packageStartupMessage(
-      "\n>>> PROBLEM encountered: couldn't build package cache! <<<\n",
-      "The 'qgis_process' command-line utility was either not found or\n",
-      "did not fulfil the needs to build the package cache.\n",
-      "Please run `qgis_configure()` to fix this and rebuild the cache.\n",
-      "See its documentation if you need to preset the path of qgis_process.\n",
-      "If the problem persists, make sure that you correctly installed QGIS\n",
-      "for your operating system using the instructions at\n",
-      "https://download.qgis.org."
-    )
+    packageStartupMessage(config_problem_msg)
   }
 }
+
+config_problem_msg <- paste0(
+  "\n>>> PROBLEM encountered: couldn't build and save package cache! <<<\n",
+  "The 'qgis_process' command-line utility was either not found or\n",
+  "did not fulfil the needs to build the package cache.\n",
+  "Please run `qgis_configure()` to fix this and rebuild the cache.\n",
+  "See its documentation if you need to preset the path of qgis_process.\n",
+  "If the problem persists, make sure that you correctly installed QGIS\n",
+  "for your operating system using the instructions at\n",
+  "https://download.qgis.org."
+)
 
 # nocov end

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -41,7 +41,7 @@ config_problem_msg <- paste0(
   "See its documentation if you need to preset the path of qgis_process.\n",
   "If the problem persists, make sure that you correctly installed QGIS\n",
   "for your operating system using the instructions at\n",
-  "https://download.qgis.org."
+  "<https://download.qgis.org>."
 )
 
 # nocov end

--- a/tests/testthat/test-qgis-run.R
+++ b/tests/testthat/test-qgis-run.R
@@ -4,8 +4,8 @@ test_that("qgis_run() has a successful fallback if path is NULL", {
   qgisprocess_cache$path <- NULL
   qgisprocess_cache$version <- NULL
 
-  expect_message({v <- qgis_version(query = TRUE)}, "on the fly")
-  expect_length(v, 1L)
+  expect_message(qgis_run(), "on the fly")
+  expect_length(qgis_version(), 1L)
 
   # both qgis_version(query = TRUE) and qgis_path(query = TRUE) restore
   # the cache values:

--- a/tests/testthat/test-qgis-run.R
+++ b/tests/testthat/test-qgis-run.R
@@ -1,0 +1,14 @@
+test_that("qgis_run() has a successful fallback if path is NULL", {
+  skip_if_not(has_qgis())
+
+  qgisprocess_cache$path <- NULL
+  qgisprocess_cache$version <- NULL
+
+  expect_message({v <- qgis_version(query = TRUE)}, "on the fly")
+  expect_length(v, 1L)
+
+  # both qgis_version(query = TRUE) and qgis_path(query = TRUE) restore
+  # the cache values:
+  expect_false(is.null(qgisprocess_cache$version))
+  expect_false(is.null(qgisprocess_cache$path))
+})


### PR DESCRIPTION
If for some reason `qgis_reconfigure()` is interrupted, the cache elements are set back to
`NULL` by `qgis_unconfigure()`, but `qgis_process` can possibly still be accessed.

An example was seen in https://github.com/r-spatial/qgisprocess/issues/176.

This PR adds some protection in order to maintain some package functionality
    in a situation where package configuration did not succeed completely, but
    `qgis_process` can be accessed nevertheless:

- making `qgis_run()` able to access the backend, will at least aid in further debugging.
- avoid erroring in `qgis_configure()` which would lead to resetting the package cache. As a result, half-configured states can emerge, but the problem of not being able to build & save the cache (which needs `has_qgis()`) is communicated to the user. Also the individual fails are reported. Moreover, the half-configured state still allows some functionality.