### PR TITLE
Implement issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/10_package_loading.yml
+++ b/.github/ISSUE_TEMPLATE/10_package_loading.yml
@@ -1,0 +1,73 @@
+name: Package does not load successfully
+description: "`library(qgisprocess)` gives an error and I am stuck."
+labels: [null]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Thanks for taking the time to fill out this bug report!
+        [Styling with Markdown](https://docs.github.com/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) is supported.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Things to check beforehand
+      description: >
+        Please consider the following tips carefully.
+        They may already solve your problem.
+      options:
+        - label: To avoid duplication, I have checked [existing issues](https://github.com/r-spatial/qgisprocess/issues?q=is%3Aissue).
+        - label: I use a currently supported QGIS version, i.e. shown _**green**_ in the [QGIS release schedule](https://www.qgis.org/en/site/getinvolved/development/roadmap.html#release-schedule).
+  - type: dropdown
+    id: plugins
+    attributes:
+      label: Are QGIS plugins the cause?
+      description: Does the R package load successfully after **disabling** all QGIS plugins in QGIS Desktop and restarting R? (_Plugins > Manage and Install Plugins..._)
+      options:
+        - -- choose --
+        - The R package loads successfully after disabling all QGIS plugins.
+        - The problem remains with all plugins disabled.
+      default: 0
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: >
+        If indeed plugins are at play, please try to narrow down the cause by
+        enabling plugins one by one, each time restarting R and loading
+        {qgisprocess}, and report back below about which plugin(s) causes the
+        issue.
+  - type: textarea
+    id: report
+    attributes:
+      label: Description of the observed problem
+      description: >
+        Please also include complete R code and output.
+        Put code blocks between triple backtick (\`\`\`) lines.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: QGIS version
+      description: What version of QGIS are you running?
+      placeholder: e.g. 3.28.1
+    validations:
+      required: true
+  - type: textarea
+    id: sessioninfo
+    attributes:
+      label: R session info
+      description: >
+        Please provide the output of `sessionInfo()` or (preferably)
+        `sessioninfo::session_info()`.
+        Put this code block between triple backtick (\`\`\`) lines.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Any other information you deem relevant, e.g. the way you have installed QGIS, or things that you tried already.
+    validations:
+      required: false
+

--- a/.github/ISSUE_TEMPLATE/20_plugin.yml
+++ b/.github/ISSUE_TEMPLATE/20_plugin.yml
@@ -1,0 +1,88 @@
+name: Processing provider or QGIS plugin problem in R
+description: "Unexpected behaviour from `qgis_plugins(query = TRUE)` or when running a plugin-provided algorithm."
+labels: [null]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Thanks for taking the time to fill out this bug report!
+        [Styling with Markdown](https://docs.github.com/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) is supported.
+  - type: markdown
+    attributes:
+      value: |
+        #### Important note
+
+        If you encounter an issue with a specific QGIS plugin in R, then **please** check whether the problem also exists in the QGIS Desktop (GUI).
+        If that is the case, then you should _not_ report the problem here, but at the plugin's bug tracking URL (issues) that you should lookup at <https://plugins.qgis.org/>. There you should formulate the problem as you encounter it in QGIS Desktop (not R).
+
+        If the plugin _only_ misbehaves in R, and not in QGIS Desktop, then please proceed below!
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks and questions
+      description: >
+        Please consider the following information carefully.
+        Some may already solve your problem, or will provide us hints to help you.
+      options:
+        - label: To avoid duplication, I have checked [existing open issues](https://github.com/r-spatial/qgisprocess/issues).
+        - label: I use a currently supported QGIS version, i.e. shown _**green**_ in the [QGIS release schedule](https://www.qgis.org/en/site/getinvolved/development/roadmap.html#release-schedule).
+        - label: In QGIS Desktop, I have updated all QGIS plugins to their current version (_Plugins > Manage and Install Plugins..._).
+        - label: I get a standard error message from `qgis_plugins(query = TRUE)`.
+  - type: dropdown
+    id: disabling
+    attributes:
+      label: Does disabling the problematic plugin(s) makes the warning or error disappear?
+      description: If "no", then consider reporting your problem in [the general issue template]() as it appears not to be linked to a plugin.
+      options:
+        - -- choose --
+        - Yes.
+        - No.
+        - "Not applicable: the problem only arises when using algorithms provided by the plugin."
+      default: 0
+    validations:
+      required: false
+  - type: textarea
+    id: report
+    attributes:
+      label: Description of the observed problem
+      description: >
+        Please also include complete R code and output.
+        Put code blocks between triple backtick (\`\`\`) lines.
+    validations:
+      required: true
+  - type: textarea
+    id: version
+    attributes:
+      label: Backend versions
+      description: >
+        Please provide the output of `qgis_version(query = TRUE, debug = TRUE)`.
+        Put this code block between triple backtick (\`\`\`) lines.
+    validations:
+      required: true
+  - type: textarea
+    id: plugins
+    attributes:
+      label: QGIS plugin state
+      description: >
+        Please provide the output of `qgis_plugins(query = TRUE)`.
+        Put this code block between triple backtick (\`\`\`) lines.
+    validations:
+      required: true
+  - type: textarea
+    id: sessioninfo
+    attributes:
+      label: R session info
+      description: >
+        Please provide the output of `sessionInfo()` or (preferably)
+        `sessioninfo::session_info()`.
+        Put this code block between triple backtick (\`\`\`) lines.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Any other information you deem relevant, e.g. the way you have installed QGIS, or things that you tried already.
+    validations:
+      required: false
+

--- a/.github/ISSUE_TEMPLATE/20_plugin.yml
+++ b/.github/ISSUE_TEMPLATE/20_plugin.yml
@@ -32,7 +32,7 @@ body:
     id: disabling
     attributes:
       label: Does disabling the problematic plugin(s) makes the warning or error disappear?
-      description: If "no", then consider reporting your problem in [the general issue template]() as it appears not to be linked to a plugin.
+      description: If "no", then consider reporting your problem in [the general issue template](https://github.com/r-spatial/qgisprocess/issues/new?template=30_other.yml) as it appears not to be linked to a plugin.
       options:
         - -- choose --
         - Yes.

--- a/.github/ISSUE_TEMPLATE/30_other.yml
+++ b/.github/ISSUE_TEMPLATE/30_other.yml
@@ -1,0 +1,95 @@
+name: Report another problem with R-package {qgisprocess}
+description: "Report other unexpected behaviour here."
+labels: [null]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Thanks for taking the time to fill out this bug report!
+        [Styling with Markdown](https://docs.github.com/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) is supported.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Things to check beforehand
+      description: >
+        Please consider the following tips carefully.
+        They may already solve your problem.
+      options:
+        - label: To avoid duplication, I have checked [existing issues](https://github.com/r-spatial/qgisprocess/issues?q=is%3Aissue).
+        - label: I use a currently supported QGIS version, i.e. shown _**green**_ in the [QGIS release schedule](https://www.qgis.org/en/site/getinvolved/development/roadmap.html#release-schedule).
+  - type: dropdown
+    id: plugins
+    attributes:
+      label: Are QGIS plugins the cause?
+      description: Does your code run successfully after **disabling** all QGIS plugins in QGIS Desktop and restarting R? (_Plugins > Manage and Install Plugins..._)
+      options:
+        - -- choose --
+        - The code runs successfully after disabling all QGIS plugins.
+        - The problem remains with all plugins disabled.
+      default: 0
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: >
+        If indeed plugins are at play, please try to narrow down the cause by
+        enabling plugins one by one, each time restarting R and rerunning your
+        code, and report back below about which plugin(s) causes the
+        issue.
+  - type: textarea
+    id: report
+    attributes:
+      label: Description of the observed problem
+    validations:
+      required: true
+  - type: textarea
+    id: reprex
+    attributes:
+      label: Minimal reproducible example
+      description: >
+        Please provide a minimal reproducible example (MRE).
+        An MRE demonstrates where the problem lies and often helps to solve it.
+        Please read what constitutes an MRE
+        [at Stack Overflow](https://stackoverflow.com/help/minimal-reproducible-example).
+        Put the code block between triple backtick (\`\`\`) lines.
+        The easiest is to copy R code in your clipboard, run
+        `reprex::reprex(session_info = TRUE)` (it updates your clipboard) and
+        paste your clipboard below.
+    validations:
+      required: false
+  - type: textarea
+    id: version
+    attributes:
+      label: Backend versions
+      description: >
+        Please provide the output of `qgis_version(query = TRUE, debug = TRUE)`.
+        Put this code block between triple backtick (\`\`\`) lines.
+    validations:
+      required: true
+  - type: textarea
+    id: plugins2
+    attributes:
+      label: QGIS plugin state
+      description: >
+        Please provide the output of `qgis_plugins(query = TRUE)`.
+        Put this code block between triple backtick (\`\`\`) lines.
+    validations:
+      required: true
+  - type: textarea
+    id: sessioninfo
+    attributes:
+      label: R session info
+      description: >
+        Please provide the output of `sessionInfo()` or (preferably)
+        `sessioninfo::session_info()`.
+        Put this code block between triple backtick (\`\`\`) lines.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Any other information you deem relevant, e.g. the way you have installed QGIS, or things that you tried already.
+    validations:
+      required: false
+

--- a/.github/ISSUE_TEMPLATE/40_feature.yml
+++ b/.github/ISSUE_TEMPLATE/40_feature.yml
@@ -1,0 +1,20 @@
+name: Feature request
+description: "Suggest an idea for a new feature."
+labels: [null]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        [Styling with Markdown](https://docs.github.com/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) is supported.
+  - type: textarea
+    id: request
+    attributes:
+      label: Description of the requested feature
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,21 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Need help with setup of QGIS plugins?
+    url: https://docs.qgis.org/latest/en/docs/user_manual/plugins/plugins.html
+    about: You first need to setup QGIS plugins outside of R, in order to access them from R.
+  - name: Need help with setup of external processing providers?
+    url: https://docs.qgis.org/latest/en/docs/user_manual/processing/3rdParty.html
+    about: You first need to setup external processing providers outside of R, in order to use them from R.
+  - name: Looking for the QGIS documentation?
+    url: https://qgis.org/en/docs/index.html
+    about: Learn about the QGIS processing framework, the QGIS GUI and more.
+  - name: Need further QGIS support?
+    url: https://qgis.org/en/site/forusers/support.html
+    about: For all QGIS questions or problems unrelated to the R-package {qgisprocess}.
+  - name: Question about using R-package {qgisprocess}?
+    url: https://gis.stackexchange.com/search?tab=newest&q=qgisprocess
+    about: >
+      Questions about using {qgisprocess} should not be posted in the GitHub
+      repo, but in a support forum like https://gis.stackexchange.com or
+      https://stackoverflow.com.
+      GitHub issues are for bug reports and suggestions for new features.


### PR DESCRIPTION
Fixes #180.

This should help users to analyze and report their problems properly, enabling developers to proceed efficiently. Setup is based on the experience with several issues in the past, and was somehow inspired by how QGIS deals with this. Different issue categories lead to a different set of questions asked.

The result has been pushed to the main branch of my fork; so you can try out at https://github.com/florisvdh/qgisprocess/issues/new/choose (screenshot below). Feel free to post some dummy issues there (posting issues in my fork will be disabled later).

**Developer community of the {qgisprocess} package**: if you're in need to add a simple housekeeping issue, e.g. a task list for yourself, use the '**feature request**' as it has the simplest form and no extra requirements. After posting, you can still edit as a normal issue.

Automated issue labelling is not enabled yet. We can consider this later on, after gathering more experience.

![afbeelding](https://github.com/r-spatial/qgisprocess/assets/19164640/7f4ff07f-7bf4-4574-82a9-1e3444cd6a16)
