### PR TITLE
Sort file paths coming out of qgis_detect_*_paths()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qgisprocess
 Title: Use 'QGIS' Processing Algorithms
-Version: 0.1.0.9180
+Version: 0.1.0.9181
 Authors@R: c(
     person("Dewey", "Dunnington", , "dewey@fishandwhistle.net", role = "aut",
            comment = c(ORCID = "0000-0002-9415-4582", affiliation = "Voltron Data")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,17 @@
 # qgisprocess (development version)
 
-- Solve a CRAN check error on `r-oldrel-macos-x86_64`, by adding support for {stars} 0.5-5 (#175).
-- Allow half-configured states with abundant messages, so that remaining functionality can be used in debugging or even for some real stuff (#177).
+## New features
+
 - Add vector support for {terra} (#184).
-This makes it possible to use SpatVector(Proxy) objects as input arguments, and to coerce processing results to SpatVector(Proxy).
+This makes it possible to use `SpatVector` or `SpatVectorProxy` objects as input arguments, and to coerce processing results to `SpatVector` or `SpatVectorProxy`.
+- `qgis_detect_windows_paths()` and `qgis_detect_macos_paths()` put paths at the top that contain a QGIS version string and these paths are sorted according to decreasing QGIS version (#189).
+This lets `qgis_configure()` prefer the newest QGIS version from `qgis_process` file paths that have a version string.
+
+## Other changes
+
+- Allow half-configured states with abundant messages, so that remaining functionality can be used in debugging or even for some real stuff (#177).
 - `qgis_run_algorithm()` documentation gains a section on QGIS models and scripts (8a20669).
+- Solve a CRAN check error on `r-oldrel-macos-x86_64`, by adding support for {stars} 0.5-5 (#175).
 
 # qgisprocess 0.1.0
 

--- a/R/qgis-detect.R
+++ b/R/qgis-detect.R
@@ -46,7 +46,8 @@ qgis_detect_windows_paths <- function(drive_letter = strsplit(R.home(), ":")[[1]
   )
 
   possible_locs_win <- file.path(posssible_locs_win_df$qgis, posssible_locs_win_df$file)
-  possible_locs_win[file.exists(possible_locs_win)]
+  possible_locs_win <- possible_locs_win[file.exists(possible_locs_win)]
+  sort_paths(possible_locs_win)
 }
 
 #' @rdname qgis_detect_windows_paths
@@ -61,7 +62,8 @@ qgis_detect_macos_paths <- function() {
     "Contents/MacOS/bin/qgis_process"
   )
 
-  possible_locs_mac[file.exists(possible_locs_mac)]
+  possible_locs_mac <- possible_locs_mac[file.exists(possible_locs_mac)]
+  sort_paths(possible_locs_mac)
 }
 
 #' @keywords internal
@@ -74,3 +76,25 @@ is_macos <- function() {
 is_windows <- function() {
   .Platform$OS.type == "windows"
 }
+
+#' @keywords internal
+sort_paths <- function(x) {
+  assert_that(is.character(x))
+  extracted <- extract_version_from_paths(x)
+  indexes_version <- order(
+    as.package_version(extracted[!is.na(extracted)]),
+    decreasing = TRUE
+  )
+  indexes <- c(
+    which(!is.na(extracted))[indexes_version],
+    which(is.na(extracted))
+  )
+  x[indexes]
+}
+
+#' @keywords internal
+extract_version_from_paths <- function(x) {
+  stringr::str_extract(x, "\\d{1,2}\\.\\d+(?:\\.\\d+)?(?=/)")
+}
+
+

--- a/tests/testthat/test-qgis-detect.R
+++ b/tests/testthat/test-qgis-detect.R
@@ -13,3 +13,48 @@ test_that("qgis_detect_windows_paths() works", {
     expect_error(qgis_detect_windows_paths(), "non-windows")
   }
 })
+
+test_that("extract_version_from_paths() works", {
+  path <- "/QGIS 3.28.6/bin/qgis_process-qgis-ltr.bat"
+  expect_identical(extract_version_from_paths(path), "3.28.6")
+  paths <- c(
+    "C:/OSGeo4W/bin/qgis_process-qgis-dev.bat",
+    "/QGIS 3.30.0/bin/qgis_process-qgis-ltr.bat",
+    "QGIS 3.30.0/bin/qgis_process-qgis-ltr.bat",
+    "QGIS 3.30/bin/qgis_process-qgis-ltr.bat",
+    "/QGIS 3.30.0",
+    "QGIS 3.30.0aaa/bin/qgis_process-qgis-ltr.bat"
+  )
+  expect_identical(
+    extract_version_from_paths(paths),
+    c(NA, "3.30.0", "3.30.0", "3.30", NA, NA)
+  )
+})
+
+test_that("sort_paths() works", {
+  paths <-
+    c(
+      "C:/OSGeo4W64/bin/qgis_process-qgis.bat",
+      "C:/OSGeo4W/bin/qgis_process-qgis.bat",
+      "C:/OSGeo4W64/bin/qgis_process-qgis-ltr.bat",
+      "C:/OSGeo4W/bin/qgis_process-qgis-ltr.bat",
+      "C:/OSGeo4W64/bin/qgis_process-qgis-dev.bat",
+      "C:/OSGeo4W/bin/qgis_process-qgis-dev.bat",
+      "C:/Program Files/QGIS 3.28.6/bin/qgis_process-qgis-ltr.bat",
+      "C:/Program Files/QGIS 3.30.0/bin/qgis_process-qgis-ltr.bat",
+      "C:/Program Files/QGIS 3.8/bin/qgis_process-qgis-ltr.bat",
+      "C:/Program Files/QGIS 3.4.6/bin/qgis_process-qgis-ltr.bat",
+      "C:/Program Files/QGIS 3.30.0aaa/bin/qgis_process-qgis-ltr.bat"
+    )
+  new_paths <- sort_paths(paths)
+  expect_setequal(paths, new_paths)
+  expect_identical(
+    new_paths[1:4],
+    c(
+      "C:/Program Files/QGIS 3.30.0/bin/qgis_process-qgis-ltr.bat",
+      "C:/Program Files/QGIS 3.28.6/bin/qgis_process-qgis-ltr.bat",
+      "C:/Program Files/QGIS 3.8/bin/qgis_process-qgis-ltr.bat",
+      "C:/Program Files/QGIS 3.4.6/bin/qgis_process-qgis-ltr.bat"
+    )
+  )
+})

--- a/tests/testthat/test-qgis-state.R
+++ b/tests/testthat/test-qgis-state.R
@@ -2,7 +2,7 @@ test_that("qgis_version() works", {
   skip_if_not(has_qgis())
 
   expect_match(qgis_version(), "^\\d{1,2}\\.\\d+.*-.+")
-  expect_match(qgis_version(full = FALSE), "^\\d{1,2}\\.\\d+.\\d+$")
+  expect_match(qgis_version(full = FALSE), "^\\d{1,2}\\.\\d+\\.\\d+$")
 })
 
 test_that("qgis_version(debug = TRUE) works", {


### PR DESCRIPTION
Based on the request in #187. `qgis_process` file paths that contain a version number are sorted first with the highest version at the top.