### PR TITLE
GHA R-CMD-check: add extra CRAN-like win/mac jobs without QGIS

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -19,18 +19,18 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macOS-latest, qgis: 'none', r: 'oldrel', dep: '', r-pkg-cache: 'v11'}
-          - {os: macOS-latest, qgis: 'none', r: 'release', dep: '', r-pkg-cache: 'v11'}
-          - {os: windows-latest, qgis: 'none', r: 'oldrel', dep: '', r-pkg-cache: 'v11'}
-          - {os: windows-latest, qgis: 'none', r: 'release', dep: '', r-pkg-cache: 'v11'}
-          - {os: windows-latest, qgis: 'none', r: 'devel', dep: '', r-pkg-cache: 'v11'}
-          - {os: ubuntu-22.04, qgis: 'none', r: 'release', dep: '', r-pkg-cache: 'v11'}
+          - {os: macOS-latest, qgis: 'none', r: 'oldrel', dep: '', r-pkg-cache: 'v0'}
+          - {os: macOS-latest, qgis: 'none', r: 'release', dep: '', r-pkg-cache: 'v0'}
+          - {os: windows-latest, qgis: 'none', r: 'oldrel', dep: '', r-pkg-cache: 'v0'}
+          - {os: windows-latest, qgis: 'none', r: 'release', dep: '', r-pkg-cache: 'v0'}
+          - {os: windows-latest, qgis: 'none', r: 'devel', dep: '', r-pkg-cache: 'v0'}
+          - {os: ubuntu-22.04, qgis: 'none', r: 'release', dep: '', r-pkg-cache: 'v0'}
           - {os: macOS-latest, qgis: 'macos-brew', r: 'release', dep: '', r-pkg-cache: 'v0'}
           - {os: windows-latest, qgis: 'chocolatey', r: 'release', dep: '', r-pkg-cache: 'v0'}
           - {os: windows-latest, qgis: 'chocolatey-ltr', r: 'release', dep: '', r-pkg-cache: 'v0'}
-          - {os: windows-latest, qgis: 'chocolatey', r: 'devel', dep: '', r-pkg-cache: 'v2'}
+          - {os: windows-latest, qgis: 'chocolatey', r: 'devel', dep: '', r-pkg-cache: 'v0'}
           - {os: ubuntu-22.04, qgis: 'ubuntu-nightly', r: 'release', dep: '', r-pkg-cache: 'v0'}
-          - {os: ubuntu-22.04, qgis: 'ubuntu-nightly', r: 'devel', dep: '', r-pkg-cache: 'v2'}
+          - {os: ubuntu-22.04, qgis: 'ubuntu-nightly', r: 'devel', dep: '', r-pkg-cache: 'v0'}
           - {os: ubuntu-22.04, qgis: 'ubuntugis', r: 'release', dep: '', r-pkg-cache: 'v1'}
           - {os: ubuntu-22.04, qgis: 'ubuntu', r: 'release', dep: '', r-pkg-cache: 'v0'}
           - {os: ubuntu-22.04, qgis: 'ubuntu', r: 'release', dep: ' [hard-deps]', r-pkg-cache: 'v3'}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -19,7 +19,10 @@ jobs:
       fail-fast: false
       matrix:
         config:
+          - {os: macOS-latest, qgis: 'none', r: 'oldrel', dep: '', r-pkg-cache: 'v11'}
           - {os: macOS-latest, qgis: 'none', r: 'release', dep: '', r-pkg-cache: 'v11'}
+          - {os: windows-latest, qgis: 'none', r: 'oldrel', dep: '', r-pkg-cache: 'v11'}
+          - {os: windows-latest, qgis: 'none', r: 'release', dep: '', r-pkg-cache: 'v11'}
           - {os: windows-latest, qgis: 'none', r: 'devel', dep: '', r-pkg-cache: 'v11'}
           - {os: ubuntu-22.04, qgis: 'none', r: 'release', dep: '', r-pkg-cache: 'v11'}
           - {os: macOS-latest, qgis: 'macos-brew', r: 'release', dep: '', r-pkg-cache: 'v0'}


### PR DESCRIPTION
It should also be noted that the r-universe runners for R-oldrel on macOS seem somewhat less reliable and need specific patching. This has been done for https://github.com/r-universe/r-spatial in 584a3db and f63925a, since that build now adds to success or failure in our main branch, but other problems for R-oldrel on macOS are still seen in https://github.com/r-universe/inbo; all having to do with processing EPSG CRSs by terra or sf it seems.