### PR TITLE
test-compat-terra.R: let CRS comparison for SpatVector depend on {terra} version

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -119,13 +119,13 @@ jobs:
 
       - name: Install QGIS (Windows chocolatey)
         if: matrix.config.qgis == 'chocolatey'
-        uses: crazy-max/ghaction-chocolatey@v2
+        uses: crazy-max/ghaction-chocolatey@v3
         with:
           args: install qgis
 
       - name: Install QGIS LTR (Windows chocolatey)
         if: matrix.config.qgis == 'chocolatey-ltr'
-        uses: crazy-max/ghaction-chocolatey@v2
+        uses: crazy-max/ghaction-chocolatey@v3
         with:
           args: install qgis-ltr
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -42,7 +42,7 @@ jobs:
       SAGANGV: 0.0.7
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -161,7 +161,7 @@ jobs:
 
       - name: Restore (or define new) R package cache
         if: matrix.config.dep == ''
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ${{ env.R_LIBS_USER }}/*

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -14,7 +14,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       SAGANGV: 0.0.7
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qgisprocess
 Title: Use 'QGIS' Processing Algorithms
-Version: 0.2.0.9003
+Version: 0.2.0.9004
 Authors@R: c(
     person("Dewey", "Dunnington", , "dewey@fishandwhistle.net", role = "aut",
            comment = c(ORCID = "0000-0002-9415-4582", affiliation = "Voltron Data")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -65,7 +65,7 @@ Config/checklist/keywords: R; package; QGIS
 Encoding: UTF-8
 Language: en-GB
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 SystemRequirements: 'QGIS' latest or long-term release, currently supported
     according to the 'QGIS' release schedule
     (<https://www.qgis.org/en/site/getinvolved/development/roadmap.html>). Older

--- a/man/st_as_sf.Rd
+++ b/man/st_as_sf.Rd
@@ -7,11 +7,11 @@
 \alias{st_as_sf.qgis_outputLayer}
 \title{Convert a qgis_result object or one of its elements to an sf object}
 \usage{
-st_as_sf.qgis_result(x, ...)
+\method{st_as_sf}{qgis_result}(x, ...)
 
-st_as_sf.qgis_outputVector(x, ...)
+\method{st_as_sf}{qgis_outputVector}(x, ...)
 
-st_as_sf.qgis_outputLayer(x, ...)
+\method{st_as_sf}{qgis_outputLayer}(x, ...)
 }
 \arguments{
 \item{x}{A \code{qgis_result} object from \code{\link[=qgis_run_algorithm]{qgis_run_algorithm()}} or a

--- a/man/st_as_stars.Rd
+++ b/man/st_as_stars.Rd
@@ -7,11 +7,11 @@
 \alias{st_as_stars.qgis_result}
 \title{Convert a qgis_result object or one of its elements to a stars object}
 \usage{
-st_as_stars.qgis_outputRaster(x, ...)
+\method{st_as_stars}{qgis_outputRaster}(x, ...)
 
-st_as_stars.qgis_outputLayer(x, ...)
+\method{st_as_stars}{qgis_outputLayer}(x, ...)
 
-st_as_stars.qgis_result(x, ...)
+\method{st_as_stars}{qgis_result}(x, ...)
 }
 \arguments{
 \item{x}{A \code{qgis_result} object from \code{\link[=qgis_run_algorithm]{qgis_run_algorithm()}} or a

--- a/tests/testthat/test-compat-terra.R
+++ b/tests/testthat/test-compat-terra.R
@@ -155,14 +155,18 @@ test_that("terra argument coercers work for SpatVector referring to a file", {
     "exactly one row and the geometry must be a point"
   )
 
-  # check effect of resetting CRS
-  obj2 <- obj
-  terra::crs(obj2) <- NA
-  res <- expect_message(
-    as_qgis_argument(obj2, qgis_argument_spec(qgis_type = "vector")),
-    "Rewriting.*since its CRS has been set to another value"
-  )
-  expect_s3_class(res, "qgis_tempfile_arg")
+  if (packageVersion("terra") <= "1.7.65") {
+    # check effect of resetting CRS
+    # In terra > 1.7-65, the source is dropped from the object
+    # when CRS is reset, so no CRS comparison will be attempted.
+    obj2 <- obj
+    terra::crs(obj2) <- NA
+    res <- expect_message(
+      as_qgis_argument(obj2, qgis_argument_spec(qgis_type = "vector")),
+      "Rewriting.*since its CRS has been set to another value"
+    )
+    expect_s3_class(res, "qgis_tempfile_arg")
+  }
 
   # check effect of changed attribute names
   obj2 <- obj


### PR DESCRIPTION
In `{terra}` > 1.7-65, a SpatVector object drops its source when its CRS is overwritten (https://github.com/rspatial/terra/issues/1372).

While `qgis_as_terra()` already works fine with the changed behaviour, one of the unit tests needed updating in order to work with `{terra}` 1.7-71, just released on CRAN.

Thanks @rhijmans for bringing this to attention.