### PR TITLE
Release candidate(s) for version 0.3.0

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "R package qgisprocess: use QGIS processing algorithms",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "GPL-3.0-or-later",
   "upload_type": "software",
   "description": "<p>R package <code>qgisprocess</code> provides seamless access to the <a href=\"https://qgis.org/en/site/\">QGIS</a> processing toolbox using the standalone <code>qgis_process</code> command-line utility. Both native and third-party (plugin) processing providers are supported. Beside referring data sources from file, also common objects from <code>sf</code>, <code>terra</code> and <code>stars</code> are supported. The native processing algorithms are documented <a href=\"https://docs.qgis.org/latest/en/docs/user_manual/processing_algs/\">at QGIS.org</a>. URL: <a href=\"https://r-spatial.github.io/qgisprocess\">https://r-spatial.github.io/qgisprocess</a>. CRAN landing page: <a href=\"https://cran.r-project.org/package=qgisprocess\">https://CRAN.R-project.org/package=qgisprocess</a>.</p>",

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -39,4 +39,4 @@ abstract: R package 'qgisprocess' provides seamless access
 identifiers:
 - type: url
   value: https://r-spatial.github.io/qgisprocess/
-version: 0.2.0
+version: 0.3.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qgisprocess
 Title: Use 'QGIS' Processing Algorithms
-Version: 0.2.0.9004
+Version: 0.3.0
 Authors@R: c(
     person("Dewey", "Dunnington", , "dewey@fishandwhistle.net", role = "aut",
            comment = c(ORCID = "0000-0002-9415-4582", affiliation = "Voltron Data")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# qgisprocess (development version)
+# qgisprocess 0.3.0
 
 ## Enhancements
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,8 +1,12 @@
+## This version includes a change at CRAN’s request
+
+This version includes a fix to solve the ERRORs in the CRAN check results page at <https://cran.r-project.org/web/checks/check_results_qgisprocess.html> (as consulted 6 Feb 2024). A unit test for 'terra' compatibility failed. It was the unit test itself that needed updating in order to comply with current 'terra' behaviour.
+
 ## R CMD check results
 
 0 errors | 0 warnings | 2 notes
 
-* checking CRAN incoming feasibility ... [12s] NOTE
+* checking CRAN incoming feasibility ... [11s] NOTE
 
   Maintainer: 'Floris Vanderhaeghe <floris.vanderhaeghe@inbo.be>'
   

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -2,11 +2,11 @@ citHeader("To cite `qgisprocess` in publications please use:")
 # begin checklist entry
 bibentry(
   bibtype = "Manual",
-  title = "R package qgisprocess: use QGIS processing algorithms. Version 0.2.0",
+  title = "R package qgisprocess: use QGIS processing algorithms. Version 0.3.0",
   author = c( author = c(person(given = "Dewey", family = "Dunnington"), person(given = "Floris", family = "Vanderhaeghe"), person(given = "Jan", family = "Caha"), person(given = "Jannes", family = "Muenchow"))),
-  year = 2023,
+  year = 2024,
   url = "https://r-spatial.github.io/qgisprocess/",
-  textVersion = "Dunnington, Dewey; Vanderhaeghe, Floris; Caha, Jan; Muenchow, Jannes (2023). R package qgisprocess: use QGIS processing algorithms. Version 0.2.0. https://github.com/r-spatial/qgisprocess/",
+  textVersion = "Dunnington, Dewey; Vanderhaeghe, Floris; Caha, Jan; Muenchow, Jannes (2024). R package qgisprocess: use QGIS processing algorithms. Version 0.3.0. https://github.com/r-spatial/qgisprocess/",
   keywords = "R; package; QGIS",
 )
 # end checklist entry


### PR DESCRIPTION
Goal is to fix #203.

The `cran_submission_0.3.0` branch essentially updates the version number, pulls future updates from `main` and `cran_comments_updates` and produces new release candidates.