### PR TITLE
Vign basic: replace provider 'grass7' by 'grass' (anticipating QGIS 3.36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,11 @@ reconfigure the package, or just
 ``` r
 library(qgisprocess)
 #> Attempting to load the package cache ... Success!
-#> QGIS version: 3.34.1-Prizren
-#> Having access to 2084 algorithms from 19 QGIS processing providers.
+#> QGIS version: 3.36.0-Maidenhead
+#> Having access to 1986 algorithms from 15 QGIS processing providers.
 #> Run `qgis_configure(use_cached_data = TRUE)` to reload cache and get more details.
+#> >>> Run `qgis_enable_plugins()` to enable 3 disabled plugins and access
+#>     their algorithms: ViewshedAnalysis, networks, valhalla
 ```
 
 ## Functionality
@@ -132,11 +134,12 @@ result <- qgis_run_algorithm(
 #> Argument `MITER_LIMIT` is unspecified (using QGIS default value).
 #> Argument `SEPARATE_DISJOINT` is unspecified (using QGIS default value).
 #> Using `OUTPUT = qgis_tmp_vector()`
+#> Using non-preferred coordinate operation between EPSG:4267 and EPSG:4326. Using +proj=pipeline +step +proj=unitconvert +xy_in=deg +xy_out=rad +step +proj=push +v_3 +step +proj=cart +ellps=clrk66 +step +proj=helmert +x=-10 +y=158 +z=187 +step +inv +proj=cart +ellps=WGS84 +step +proj=pop +v_3 +step +proj=unitconvert +xy_in=rad +xy_out=deg, preferred +proj=pipeline +step +proj=unitconvert +xy_in=deg +xy_out=rad +step +proj=hgridshift +grids=ca_nrc_ntv2_0.tif +step +proj=unitconvert +xy_in=rad +xy_out=deg.
 
 result
 #> <Result of `qgis_run_algorithm("native:buffer", ...)`>
 #> List of 1
-#>  $ OUTPUT: 'qgis_outputVector' chr "/tmp/RtmpQlJBjV/file1046b3f8fd4a3/file1046b37e1f09.gpkg"
+#>  $ OUTPUT: 'qgis_outputVector' chr "/tmp/Rtmp9kZc3I/file47aa7f97cbcc/file47aa28bb3585.gpkg"
 
 output_sf <- sf::st_as_sf(result)
 plot(sf::st_geometry(output_sf))
@@ -151,20 +154,19 @@ matching with regex).
 
 ``` r
 qgis_search_algorithms(algorithm = "buffer", group = "[Vv]ector")
-#> # A tibble: 11 × 5
+#> # A tibble: 10 × 5
 #>    provider provider_title    group                algorithm     algorithm_title
 #>    <chr>    <chr>             <chr>                <chr>         <chr>          
 #>  1 gdal     GDAL              Vector geoprocessing gdal:bufferv… Buffer vectors 
 #>  2 gdal     GDAL              Vector geoprocessing gdal:oneside… One side buffer
-#>  3 grass7   GRASS             Vector (v.*)         grass7:v.buf… v.buffer       
+#>  3 grass    GRASS             Vector (v.*)         grass:v.buff… v.buffer       
 #>  4 native   QGIS (native c++) Vector geometry      native:buffer Buffer         
 #>  5 native   QGIS (native c++) Vector geometry      native:buffe… Variable width…
 #>  6 native   QGIS (native c++) Vector geometry      native:multi… Multi-ring buf…
 #>  7 native   QGIS (native c++) Vector geometry      native:singl… Single sided b…
 #>  8 native   QGIS (native c++) Vector geometry      native:taper… Tapered buffers
 #>  9 native   QGIS (native c++) Vector geometry      native:wedge… Create wedge b…
-#> 10 qgis     QGIS              Vector geometry      qgis:variabl… Variable dista…
-#> 11 sagang   SAGA Next Gen     Vector general       sagang:shape… Shapes buffer
+#> 10 sagang   SAGA Next Gen     Vector general       sagang:shape… Shapes buffer
 ```
 
 You can read the help associated with an algorithm using
@@ -178,7 +180,7 @@ A full list of available algorithms is returned by `qgis_algorithms()`.
 
 ``` r
 qgis_algorithms()
-#> # A tibble: 2,084 × 24
+#> # A tibble: 1,986 × 24
 #>    provider  provider_title algorithm               algorithm_id algorithm_title
 #>    <chr>     <chr>          <chr>                   <chr>        <chr>          
 #>  1 3d        QGIS (3D)      3d:tessellate           tessellate   Tessellate     
@@ -191,7 +193,7 @@ qgis_algorithms()
 #>  8 NetworkGT NetworkGT      NetworkGT:Connect Y No… Connect Y N… Connect Y Nodes
 #>  9 NetworkGT NetworkGT      NetworkGT:Contour Grid  Contour Grid Contour Grid   
 #> 10 NetworkGT NetworkGT      NetworkGT:Define Fract… Define Frac… Define Fractur…
-#> # ℹ 2,074 more rows
+#> # ℹ 1,976 more rows
 #> # ℹ 19 more variables: provider_can_be_activated <lgl>,
 #> #   provider_is_active <lgl>, provider_long_name <chr>, provider_version <chr>,
 #> #   provider_warning <chr>, can_cancel <lgl>, deprecated <lgl>, group <chr>,

--- a/man/vignette_childs/_qgisprocess.Rmd
+++ b/man/vignette_childs/_qgisprocess.Rmd
@@ -189,6 +189,9 @@ Hence, if you prefer running QGIS with callable R functions, check it out.
 As a second example, let's have a look at how to do raster processing running GRASS GIS in the background.
 To compute various terrain attributes of a digital elevation model, we can use `grass:r.slope.aspect`.
 
+_Note: in QGIS versions < 3.36, the processing provider was still called `grass7` (even though this provider works with GRASS GIS 8)._
+_So if you have an older QGIS version, you must name the algorithms as `grass7:r.slope.aspect` etc._
+
 `qgis_get_description()` (also included in `qgis_show_help()`) gives us the general description of the algorithm.
 
 ```{r desc}

--- a/man/vignette_childs/_qgisprocess.Rmd
+++ b/man/vignette_childs/_qgisprocess.Rmd
@@ -187,24 +187,24 @@ Hence, if you prefer running QGIS with callable R functions, check it out.
 ## Second example
 
 As a second example, let's have a look at how to do raster processing running GRASS GIS in the background.
-To compute various terrain attributes of a digital elevation model, we can use `grass7:r.slope.aspect`.
+To compute various terrain attributes of a digital elevation model, we can use `grass:r.slope.aspect`.
 
 `qgis_get_description()` (also included in `qgis_show_help()`) gives us the general description of the algorithm.
 
 ```{r desc}
-qgis_get_description("grass7:r.slope.aspect")
+qgis_get_description("grass:r.slope.aspect")
 ```
 
 We can find out about the arguments again with the help of `qgis_get_argument_specs()`.
 
 ```{r args}
-qgis_get_argument_specs("grass7:r.slope.aspect")
+qgis_get_argument_specs("grass:r.slope.aspect")
 ```
 
 `qgis_get_output_specs()` shows the different outputs that will be calculated:
 
 ```{r outputs}
-qgis_get_output_specs("grass7:r.slope.aspect")
+qgis_get_output_specs("grass:r.slope.aspect")
 ```
 
 Now let us calculate the terrain attributes.
@@ -215,7 +215,7 @@ library("terra")
 dem <- rast(system.file("raster/dem.tif", package = "spDataLarge"))
 # if not already done, enable the GRASS GIS plugin
 # qgis_enable_plugins("grassprovider")
-info <- qgis_run_algorithm(alg = "grass7:r.slope.aspect", elevation = dem)
+info <- qgis_run_algorithm(alg = "grass:r.slope.aspect", elevation = dem)
 ```
 
 Just printing the `info` object shows which output files have been made:
@@ -228,7 +228,7 @@ Combine these output rasters as a multi-layered `SpatRaster` object and plot it:
 
 ```{r combine1, message=FALSE}
 # just keep the names of output rasters
-nms <- qgis_get_output_specs("grass7:r.slope.aspect")$name
+nms <- qgis_get_output_specs("grass:r.slope.aspect")$name
 # read in the output rasters 
 r <- info[nms] |>
   unlist() |>

--- a/tests/testthat/test-qgis-run-algorithm.R
+++ b/tests/testthat/test-qgis-run-algorithm.R
@@ -93,10 +93,10 @@ test_that(glue("qgis_run_algorithm() works when passing a numeric vector to a ra
   skip_if(!("GRASS" %in% qgis_providers()$provider_title), "GRASS is not available")
 
   obj <- terra::rast(system.file("longlake/longlake_depth.tif", package = "qgisprocess"))
-  out <- qgis_run_algorithm("grass7:r.rescale", input = obj, to = c(0, 1))
+  out <- qgis_run_algorithm("grass:r.rescale", input = obj, to = c(0, 1))
   tmp <- qgis_as_terra(out)
   expect_identical(max(terra::values(tmp), na.rm = TRUE), 1L)
-  out2 <- qgis_run_algorithm("grass7:r.rescale", input = obj, to = "0,1")
+  out2 <- qgis_run_algorithm("grass:r.rescale", input = obj, to = "0,1")
   tmp2 <- qgis_as_terra(out2)
   expect_identical(terra::values(tmp), terra::values(tmp2))
 })

--- a/tests/testthat/test-qgis-run-algorithm.R
+++ b/tests/testthat/test-qgis-run-algorithm.R
@@ -91,12 +91,17 @@ test_that(glue("qgis_run_algorithm() works when passing a numeric vector to a ra
   skip_if_not(has_qgis())
   skip_if_not_installed("terra")
   skip_if(!("GRASS" %in% qgis_providers()$provider_title), "GRASS is not available")
+  grass_provider <- ifelse(
+    package_version(qgis_version(full = FALSE)) < "3.35.0",
+    "grass7",
+    "grass"
+  )
 
   obj <- terra::rast(system.file("longlake/longlake_depth.tif", package = "qgisprocess"))
-  out <- qgis_run_algorithm("grass:r.rescale", input = obj, to = c(0, 1))
+  out <- qgis_run_algorithm(glue("{grass_provider}:r.rescale"), input = obj, to = c(0, 1))
   tmp <- qgis_as_terra(out)
   expect_identical(max(terra::values(tmp), na.rm = TRUE), 1L)
-  out2 <- qgis_run_algorithm("grass:r.rescale", input = obj, to = "0,1")
+  out2 <- qgis_run_algorithm(glue("{grass_provider}:r.rescale"), input = obj, to = "0,1")
   tmp2 <- qgis_as_terra(out2)
   expect_identical(terra::values(tmp), terra::values(tmp2))
 })

--- a/vignettes/qgisprocess.Rmd
+++ b/vignettes/qgisprocess.Rmd
@@ -23,6 +23,8 @@ knitr::opts_chunk$set(
   comment = "#>"
 )
 can_build <- qgisprocess::has_qgis() &&
+  # 'grass7' provider label has changed to 'grass' in 3.35 (dev)
+  package_version(qgisprocess::qgis_version(full = FALSE)) >= "3.35.0" &&
   all(qgisprocess::qgis_has_plugin(c(
     "grassprovider",
     "processing_saga_nextgen"


### PR DESCRIPTION
This is needed for the pkgdown site to build once QGIS 3.36 is released in the 'ubuntu' repo of QGIS. And to fix the vignette building in R-CMD-check at that time (already broken for ubuntu-nightly QGIS).

It also checks the minimum needed QGIS version to build this vignette, in order to prevent build errors with older QGIS versions.

- [x] Still to be added once QGIS 3.36 is available: updated build of README.

See https://github.com/qgis/QGIS/pull/56196 for the related QGIS update; see https://github.com/OSGeo/grass/discussions/3047 for the referred QGIS-GRASS meeting minutes.