### PR TITLE
Speed up by using '--skip-loading-plugins' in specific 'qgis_process' calls

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qgisprocess
 Title: Use 'QGIS' Processing Algorithms
-Version: 0.3.0.9000
+Version: 0.3.0.9001
 Authors@R: c(
     person("Dewey", "Dunnington", , "dewey@fishandwhistle.net", role = "aut",
            comment = c(ORCID = "0000-0002-9415-4582", affiliation = "Voltron Data")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # qgisprocess (development version)
 
+- Speed up various calls to the `qgis_process` backend by automatically implementing `--skip-loading-plugins` where possible (#201).
+This benefits package startup time and the timing of `qgis_run_algorithm()`, `qgis_show_help()`, and several other functions.
+This feature needs QGIS >= 3.36.
+- Update the 'getting started' vignette (#206, #207):
+  - advise using `qgis_search_algorithms()`.
+  - in QGIS >= 3.36 the GRASS GIS provider is called `grass` instead of `grass7`.
+
 # qgisprocess 0.3.0
 
 ## Enhancements

--- a/R/qgis-algorithms.R
+++ b/R/qgis-algorithms.R
@@ -119,6 +119,14 @@ check_algorithm_deprecation <- function(algorithm, skip = FALSE) {
 }
 
 
+
+#' @keywords internal
+algorithm_is_native <- function(algorithm) {
+  stringr::str_match(algorithm, "^(\\w+):.*")[, 2] %in%
+    c("native", "3d", "pdal")
+}
+
+
 #' @keywords internal
 qgis_query_algorithms <- function(quiet = FALSE) {
   if (qgis_using_json_output()) {

--- a/R/qgis-help.R
+++ b/R/qgis-help.R
@@ -104,7 +104,12 @@ qgis_help_json <- function(algorithm, check_deprecation = TRUE) {
   assert_qgis_algorithm(algorithm, check_deprecation = check_deprecation)
 
   result <- qgis_run(
-    args = c("--json", "help", algorithm),
+    args = c(
+      "--json",
+      arg_skip_loading_plugins(algorithm),
+      "help",
+      algorithm
+    ),
     encoding = "UTF-8"
   )
 
@@ -127,7 +132,7 @@ qgis_help_text <- function(algorithm, check_deprecation = TRUE) {
   assert_qgis_algorithm(algorithm, check_deprecation = check_deprecation)
 
   result <- qgis_run(
-    args = c("help", algorithm)
+    args = c(arg_skip_loading_plugins(algorithm), "help", algorithm)
   )
 
   try({

--- a/R/qgis-plugins.R
+++ b/R/qgis-plugins.R
@@ -98,8 +98,9 @@ qgis_plugins <- function(
 
 #' @keywords internal
 qgis_query_plugins <- function(quiet = FALSE) {
+  arg_skip_loading <- arg_skip_loading_plugins()
   if (qgis_using_json_output()) {
-    result <- qgis_run(args = c("plugins", "--json"))
+    result <- qgis_run(args = c("plugins", "--json", arg_skip_loading))
     if (nchar(result$stderr) > 0L) {
       message(
         "\nStandard error message from 'qgis_process':\n",
@@ -112,7 +113,7 @@ qgis_query_plugins <- function(quiet = FALSE) {
     plugins$value <- unlist(plugins$value, use.names = FALSE)
     colnames(plugins) <- c("name", "enabled")
   } else {
-    result <- qgis_run("plugins")
+    result <- qgis_run(args = c("plugins", arg_skip_loading))
     if (nchar(result$stderr) > 0L) {
       message(
         "\nStandard error message from 'qgis_process':\n",

--- a/R/qgis-plugins.R
+++ b/R/qgis-plugins.R
@@ -135,6 +135,18 @@ qgis_query_plugins <- function(quiet = FALSE) {
 
 
 
+#' @keywords internal
+arg_skip_loading_plugins <- function(algorithm = NULL) {
+  if (!is.null(algorithm) && !algorithm_is_native(algorithm)) {
+    return(NULL)
+  }
+  if (package_version(qgis_version(full = FALSE)) >= "3.36.0") {
+    "--skip-loading-plugins"
+  } else NULL
+}
+
+
+
 
 #' @keywords internal
 message_disabled_plugins <- function(

--- a/R/qgis-plugins.R
+++ b/R/qgis-plugins.R
@@ -185,7 +185,9 @@ handle_plugins <- function(names = NULL, quiet = FALSE, mode) {
 
   if (is.null(names)) {
     names <- qgis_plugins(which = moded_rev)$name
-    names <- names[names != "processing"]
+    if (mode == "disable") {
+      names <- names[names != "processing"]
+    }
   } else {
     assert_that(is.character(names))
     names_old <- names
@@ -200,11 +202,13 @@ handle_plugins <- function(names = NULL, quiet = FALSE, mode) {
       "{paste(names_skip, collapse = ', ')}"
     ))
     names <- names_old[names_old %in% qgis_plugins(which = moded_rev)$name]
-    if (!quiet && "processing" %in% names) message(
+    if (!quiet && "processing" %in% names && mode == "disable") message(
       "Ignoring the 'processing' plugin, because it is always available to ",
       "'qgis_process' (not QGIS though)."
     )
-    names <- names[names != "processing"]
+    if (mode == "disable") {
+      names <- names[names != "processing"]
+    }
   }
 
   if (length(names) == 0L) {

--- a/R/qgis-run-algorithm.R
+++ b/R/qgis-run-algorithm.R
@@ -121,6 +121,7 @@ qgis_run_algorithm <- function(algorithm, ..., PROJECT_PATH = NULL, ELLIPSOID = 
   result <- qgis_run(
     args = c(
       if (use_json_output) "--json",
+      arg_skip_loading_plugins(algorithm),
       "run",
       algorithm,
       if (use_json_input) "-" else args_str

--- a/tests/testthat/test-qgis-algorithms.R
+++ b/tests/testthat/test-qgis-algorithms.R
@@ -47,6 +47,14 @@ test_that("Internal function check_algorithm_deprecation() works", {
   expect_no_warning(check_algorithm_deprecation(alg_non_deprecated))
 })
 
+test_that("Internal function algorithm_is_native() works", {
+  expect_true(algorithm_is_native("native:algorithm"))
+  expect_true(algorithm_is_native("3d:algorithm"))
+  expect_true(algorithm_is_native("pdal:algorithm"))
+  expect_false(algorithm_is_native("qgis:algorithm"))
+  expect_false(algorithm_is_native("grass:algorithm"))
+})
+
 test_that("qgis_search_algorithms() works", {
   skip_if_not(has_qgis())
   expect_error(qgis_search_algorithms(), "at least one of the arguments")

--- a/tests/testthat/test-qgis-plugins.R
+++ b/tests/testthat/test-qgis-plugins.R
@@ -186,6 +186,14 @@ test_that("qgis_*able_plugins() works for an enabled grassprovider plugin", {
 
 
 
+test_that("{en,dis}able_plugin can return an error message from qgis_process", {
+  local_mocked_bindings(qgis_run = function(...) stop("Some error"))
+  expect_message(enable_plugin("p1"), "not successfully enabled.+Some error")
+  expect_message(disable_plugin("p1"), "not successfully disabled.+Some error")
+})
+
+
+
 test_that("Internal function arg_skip_loading_plugins() works", {
   expect_null(arg_skip_loading_plugins("grass:algorithm"))
 

--- a/tests/testthat/test-qgis-plugins.R
+++ b/tests/testthat/test-qgis-plugins.R
@@ -84,6 +84,19 @@ test_that("qgis_disable_plugins() messages are OK", {
     qgis_disable_plugins(names = "notaplugin"),
     "Ignoring unknown plugins: notaplugin"
   )
+
+  # checking that a bare qgis_disable_plugins() never disables processing
+  local_mocked_bindings(
+    qgis_plugins = function(...) {
+      tibble::tibble(
+        name = c("plugin_1", "processing"),
+        enabled = TRUE
+      )
+    },
+    qgis_run = function(...) NULL,
+    qgis_configure = function(...) NULL
+  )
+  expect_no_message(qgis_disable_plugins(), message = "\\bprocessing\\b")
 })
 
 

--- a/tests/testthat/test-qgis-plugins.R
+++ b/tests/testthat/test-qgis-plugins.R
@@ -2,21 +2,18 @@ test_that("qgis_plugins(which = \"all\", query = FALSE) returns sensible things"
   skip_if_not(has_qgis())
   plugins <- qgis_plugins(which = "all", query = FALSE)
   expect_correct_plugins_format(plugins)
-  expect_gte(sum(plugins$enabled), 1)
 })
 
 test_that("qgis_plugins(which = \"enabled\", query = FALSE) returns sensible things", {
   skip_if_not(has_qgis())
   plugins <- qgis_plugins(which = "enabled", query = FALSE)
   expect_correct_plugins_format(plugins)
-  expect_gte(sum(plugins$enabled), 1)
 })
 
 test_that("qgis_plugins(which = \"disabled\", query = FALSE) returns sensible things", {
   skip_if_not(has_qgis())
   plugins <- qgis_plugins(which = "disabled", query = FALSE)
   expect_correct_plugins_format(plugins)
-  expect_gte(sum(!plugins$enabled), 0)
 })
 
 test_that("qgis_plugins(query = FALSE, quiet = FALSE) messages are OK", {
@@ -41,7 +38,6 @@ test_that(glue("qgis_plugins(query = TRUE) works when using JSON output"), {
 
   plugins <- qgis_plugins(query = TRUE)
   expect_correct_plugins_format(plugins)
-  expect_gte(sum(plugins$enabled), 1)
 })
 
 test_that(glue("qgis_plugins(query = TRUE) works when NOT using JSON output"), {
@@ -53,7 +49,6 @@ test_that(glue("qgis_plugins(query = TRUE) works when NOT using JSON output"), {
 
   plugins <- qgis_plugins(query = TRUE)
   expect_correct_plugins_format(plugins)
-  expect_gte(sum(plugins$enabled), 1)
 })
 
 

--- a/tests/testthat/test-qgis-plugins.R
+++ b/tests/testthat/test-qgis-plugins.R
@@ -67,10 +67,6 @@ test_that("qgis_enable_plugins() messages are OK", {
   skip_if_not(has_qgis())
   expect_message(qgis_enable_plugins(names = ""), "exiting")
   expect_message(
-    qgis_enable_plugins(names = "processing"),
-    "Ignoring.+processing"
-  )
-  expect_message(
     qgis_enable_plugins(names = "notaplugin"),
     "Ignoring unknown plugins: notaplugin"
   )

--- a/tests/testthat/test-qgis-plugins.R
+++ b/tests/testthat/test-qgis-plugins.R
@@ -179,3 +179,28 @@ test_that("qgis_*able_plugins() works for an enabled grassprovider plugin", {
   )
   expect_true(subset(qgis_plugins(), name == "grassprovider")$enabled)
 })
+
+
+
+test_that("Internal function arg_skip_loading_plugins() works", {
+  expect_null(arg_skip_loading_plugins("grass:algorithm"))
+
+  local_mocked_bindings(
+    qgis_version = function(...) "3.34.0" # --skip-loading-plugins not supported
+  )
+
+  expect_null(arg_skip_loading_plugins("grass:algorithm"))
+  expect_null(arg_skip_loading_plugins("native:algorithm"))
+  expect_null(arg_skip_loading_plugins())
+
+  local_mocked_bindings(
+    qgis_version = function(...) "3.36.0" # --skip-loading-plugins supported
+  )
+
+  expect_null(arg_skip_loading_plugins("grass:algorithm"))
+  expect_identical(
+    arg_skip_loading_plugins("native:algorithm"),
+    "--skip-loading-plugins"
+  )
+  expect_identical(arg_skip_loading_plugins(), "--skip-loading-plugins")
+})


### PR DESCRIPTION
Fixes #201.

Depending on the number of installed processing provider plugins, the speed gain can be considerable!