### PR TITLE
Update pkgdown.yml and extra.css to ensure that the site rendering under pkgdown2.1.0 is the same as before

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: local::., pkgdown@2.0.9
+          extra-packages: any::pkgdown, local::.
           needs: website
 
       - name: Deploy package

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -1,12 +1,11 @@
 url: https://r-spatial.github.io/qgisprocess
 template:
   bootstrap: 5
+  bslib:
+    pkgdown-navbar-bg: '#497d29'
 
 navbar:
   bg: custom
-  structure:
-    right: [github, twitter, linkedin]
-
   components:
     github:
      icon: fa-github
@@ -15,26 +14,26 @@ navbar:
 
 reference:
 - title: "Discover and learn geoprocessing algorithms"
-- contents:
+  contents:
   - has_concept("topics about information on algorithms & processing providers")
 - title: "Prepare special input arguments"
-- contents:
+  contents:
   - has_concept("topics about preparing input values")
 - title: "Run geoprocessing algorithms"
-- contents:
+  contents:
   - has_concept("functions to run one geoprocessing algorithm")
   - qgis_function
 - title: "Handle processing results"
-- contents:
+  contents:
   - qgis_extract_output
   - qgis_clean_result
   - has_concept("main functions to access or manage processing results")
 - title: "Coerce processing output"
-- contents:
+  contents:
   - has_concept("topics about coercing processing output")
 - title: "Explore and manage QGIS and qgisprocess state"
-- contents:
+  contents:
   - has_concept("functions to manage and explore QGIS and qgisprocess")
 - title: "Programming and debugging"
-- contents:
+  contents:
   - has_concept("topics about programming or debugging utilities")

--- a/pkgdown/extra.css
+++ b/pkgdown/extra.css
@@ -13,12 +13,7 @@ h1,h2,h3 {
   font-weight: bold;
 }
 
-
-.navbar-dark {
-    background-color:#497d29;
-}
-
-.navbar-dark input[type="search"] {
+.nav-item input[type="search"] {
     border-color: #6c757d;
     background-color: #ffffff;
     color: #212529;


### PR DESCRIPTION
- In pkgdown.yml, specify the background color of the navigation bar by using `pkgdown-navbar-bg` under `bslib`
- Modify the background color of the search box by modifying extra.css
- Synchronously update the GHA of pkgdown