### PR TITLE
get rid of encoding argument

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::pkgdown, local::.
+          extra-packages: local::., pkgdown@2.0.9
           needs: website
 
       - name: Deploy package

--- a/R/qgis-algorithms.R
+++ b/R/qgis-algorithms.R
@@ -130,7 +130,7 @@ algorithm_is_native <- function(algorithm) {
 #' @keywords internal
 qgis_query_algorithms <- function(quiet = FALSE) {
   if (qgis_using_json_output()) {
-    result <- qgis_run(args = c("list", "--json"), encoding = "UTF-8")
+    result <- qgis_run(args = c("list", "--json"))
     if (nchar(result$stderr) > 0L) {
       message(
         "\nStandard error message from 'qgis_process':\n",


### PR DESCRIPTION
This addresses and solves #218.
 `qgis_run()` calls `processx::run()`.
In the documentation of the latter it says on the `encoding` argument:
>  The encoding to assume for stdout and stderr. By default the encoding of the current locale is used. Note that processx always reencodes the output of both streams in UTF-8 currently.

Hence, it seems there is no need to explicitly set the encoding. 
What do you think @florisvdh?
 Or am I overlooking any unwanted side-effects?
FYI: `devtools::check()` also runs successfully with this modification. 
