### PR TITLE
Drop encoding = "UTF-8" for JSON in all places

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qgisprocess
 Title: Use 'QGIS' Processing Algorithms
-Version: 0.4.0
+Version: 0.4.0.9000
 Authors@R: c(
     person("Dewey", "Dunnington", , "dewey@fishandwhistle.net", role = "aut",
            comment = c(ORCID = "0000-0002-9415-4582", affiliation = "Voltron Data")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# qgisprocess (development version)
+
 # qgisprocess 0.4.0
 
 ## Enhancements

--- a/R/qgis-help.R
+++ b/R/qgis-help.R
@@ -109,8 +109,7 @@ qgis_help_json <- function(algorithm, check_deprecation = TRUE) {
       arg_skip_loading_plugins(algorithm),
       "help",
       algorithm
-    ),
-    encoding = "UTF-8"
+    )
   )
 
   try({

--- a/R/qgis-run-algorithm.R
+++ b/R/qgis-run-algorithm.R
@@ -137,8 +137,7 @@ qgis_run_algorithm <- function(algorithm, ..., PROJECT_PATH = NULL, ELLIPSOID = 
     echo_cmd = !.quiet,
     stdout_callback = if (!.quiet && !use_json_output) function(x, ...) cat(x),
     stderr_callback = function(x, ...) message(x, appendLF = FALSE),
-    stdin = if (use_json_input) stdin_file,
-    encoding = if (use_json_output) "UTF-8" else ""
+    stdin = if (use_json_input) stdin_file
   )
 
   if (!.quiet) cat("\n")

--- a/README.Rmd
+++ b/README.Rmd
@@ -139,6 +139,7 @@ Please note that the qgisprocess project is released with a [Contributor Code of
 
 ### Presentations
 
+- useR! 2024: [slides](https://florisvdh.github.io/user-2024-qgisprocess)
 - FOSS4G 2023: [slides](https://florisvdh.github.io/foss4g-2023-qgisprocess/) & [video](https://www.youtube.com/watch?v=Qt5DzWThWqI)
 - FOSS4G 2021: [slides](https://dewey.dunnington.ca/slides/qgisprocess2021/) & [video](https://www.youtube.com/watch?v=iA0OQ2Icn6Y&t=1912s)
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ reconfigure the package, or just
 ``` r
 library(qgisprocess)
 #> Attempting to load the package cache ... Success!
-#> QGIS version: 3.38.0-Grenoble
+#> QGIS version: 3.38.2-Grenoble
 #> Having access to 2059 algorithms from 18 QGIS processing providers.
 #> Run `qgis_configure(use_cached_data = TRUE)` to reload cache and get more details.
 ```
@@ -137,7 +137,7 @@ result <- qgis_run_algorithm(
 result
 #> <Result of `qgis_run_algorithm("native:buffer", ...)`>
 #> List of 1
-#>  $ OUTPUT: 'qgis_outputVector' chr "/tmp/RtmphNqw6p/file1d6937316438/file1d6950ffc83a.gpkg"
+#>  $ OUTPUT: 'qgis_outputVector' chr "/tmp/RtmpLKaaqm/file7b6c2bf628b2/file7b6c44bc6b35.gpkg"
 
 output_sf <- sf::st_as_sf(result)
 plot(sf::st_geometry(output_sf))
@@ -221,6 +221,8 @@ By contributing to this project, you agree to abide by its terms.
 
 ### Presentations
 
+- useR! 2024:
+  [slides](https://florisvdh.github.io/user-2024-qgisprocess)
 - FOSS4G 2023:
   [slides](https://florisvdh.github.io/foss4g-2023-qgisprocess/) &
   [video](https://www.youtube.com/watch?v=Qt5DzWThWqI)

--- a/man/qgisprocess-package.Rd
+++ b/man/qgisprocess-package.Rd
@@ -6,7 +6,7 @@
 \alias{qgisprocess-package}
 \title{qgisprocess: Use 'QGIS' Processing Algorithms}
 \description{
-Provides seamless access to the 'QGIS' (\url{https://qgis.org/en/site/}) processing toolbox using the standalone 'qgis_process' command-line utility. Both native and third-party (plugin) processing providers are supported. Beside referring data sources from file, also common objects from 'sf', 'terra' and 'stars' are supported. The native processing algorithms are documented by QGIS.org (2023) \url{https://docs.qgis.org/latest/en/docs/user_manual/processing_algs/}.
+Provides seamless access to the 'QGIS' (\url{https://qgis.org/en/site/}) processing toolbox using the standalone 'qgis_process' command-line utility. Both native and third-party (plugin) processing providers are supported. Beside referring data sources from file, also common objects from 'sf', 'terra' and 'stars' are supported. The native processing algorithms are documented by QGIS.org (2024) \url{https://docs.qgis.org/latest/en/docs/user_manual/processing_algs/}.
 }
 \note{
 A structured overview of the available functions can be consulted at


### PR DESCRIPTION
It appears that `processx::run()` supports UTF-8 characters in all system locales (see PR #219). Also, it was observed that {qgisprocess} doesn't work successfully in non-UTF-8 locales (#218). Relaxing the UTF-8 requirement in some `qgis_run()` statements (those that set the `encoding` argument) appears to circumvent this (see #218 and PR #219), even while JSON is UTF-8 by definition.

This PR amends PR #219.

We'll see whether this would pose new problems; as of now none have been found (tests done locally in Linux Mint & Windows).